### PR TITLE
Remove prefix from modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ A lot of inspiration has been drawn from [foreman-ansible-modules](https://githu
 Available modules
 ---
 
-* `pulp_ansible_distribution`
-* `pulp_ansible_remote`
-* `pulp_ansible_repository`
-* `pulp_ansible_role`
-* `pulp_ansible_sync`
-* `pulp_artifact`
-* `pulp_delete_orphans`
-* `pulp_file_content`
-* `pulp_file_distribution`
-* `pulp_file_publication`
-* `pulp_file_remote`
-* `pulp_file_repository`
-* `pulp_file_sync`
+* `ansible_distribution`
+* `ansible_remote`
+* `ansible_repository`
+* `ansible_role`
+* `ansible_sync`
+* `artifact`
+* `delete_orphans`
+* `file_content`
+* `file_distribution`
+* `file_publication`
+* `file_remote`
+* `file_repository`
+* `file_sync`
 * `python_distribution`
 * `python_publication`
 * `python_remote`
 * `python_repository`
 * `python_sync`
-* `pulp_status`
+* `status`
 * `task`
 
 Installation

--- a/plugins/modules/ansible_distribution.py
+++ b/plugins/modules/ansible_distribution.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_ansible_distribution
+module: ansible_distribution
 short_description: Manage ansible distributions of a pulp server
 description:
   - "This performs CRUD operations on ansible distributions in a pulp server."
@@ -51,7 +51,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of ansible distributions from pulp api server
-  pulp_ansible_distribution:
+  ansible_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -61,7 +61,7 @@ EXAMPLES = r'''
     var: distribution_status
 
 - name: Create an ansible distribution
-  pulp_ansible_distribution:
+  ansible_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -71,7 +71,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Delete an ansible distribution
-  pulp_ansible_distribution:
+  ansible_distribution:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/ansible_remote.py
+++ b/plugins/modules/ansible_remote.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_ansible_remote
+module: ansible_remote
 short_description: Manage ansible remotes of a pulp api server instance
 description:
   - "This performs CRUD operations on ansible remotes in a pulp api server instance."
@@ -50,7 +50,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of ansible remotes from pulp api server
-  pulp_ansible_remote:
+  ansible_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -59,7 +59,7 @@ EXAMPLES = r'''
   debug:
     var: remote_status
 - name: Create a ansible remote
-  pulp_ansible_remote:
+  ansible_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -67,7 +67,7 @@ EXAMPLES = r'''
     url: http://localhost/TODO
     state: present
 - name: Delete a ansible remote
-  pulp_ansible_remote:
+  ansible_remote:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/ansible_repository.py
+++ b/plugins/modules/ansible_repository.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_ansible_repository
+module: ansible_repository
 short_description: Manage ansible repositories of a pulp api server instance
 description:
   - "This performs CRUD operations on ansible repositories in a pulp api server instance."
@@ -32,7 +32,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of ansible repositories from pulp api server
-  pulp_ansible_repository:
+  ansible_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -41,7 +41,7 @@ EXAMPLES = r'''
   debug:
     var: repo_status
 - name: Create a ansible repository
-  pulp_ansible_repository:
+  ansible_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -49,7 +49,7 @@ EXAMPLES = r'''
     description: A brand new repository with a description
     state: present
 - name: Delete a ansible repository
-  pulp_ansible_repository:
+  ansible_repository:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/ansible_role.py
+++ b/plugins/modules/ansible_role.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_ansible_role
+module: ansible_role
 short_description: Manage ansible roles of a pulp server
 description:
   - "This performs CRUD operations on ansible roles in a pulp server."
@@ -42,7 +42,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of file content units from pulp api server
-  pulp_ansible_role:
+  ansible_role:
     api_url: localhost:24817
     username: admin
     password: password
@@ -51,7 +51,7 @@ EXAMPLES = r'''
   debug:
     var: content_status
 - name: Create an ansible role
-  pulp_ansible_role:
+  ansible_role:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/ansible_sync.py
+++ b/plugins/modules/ansible_sync.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_ansible_sync
+module: ansible_sync
 short_description: Synchronize a ansible remote on a pulp server
 description:
   - "This module synchronizes a ansible remote into a repository."
@@ -33,7 +33,7 @@ author:
 
 EXAMPLES = r'''
 - name: Sync ansible remote into repository
-  pulp_ansible_sync:
+  ansible_sync:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/artifact.py
+++ b/plugins/modules/artifact.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_artifact
+module: artifact
 short_description: Manage artifacts of a pulp api server instance
 description:
   - "This performs CRD operations on artifacts in a pulp api server instance."
@@ -33,7 +33,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of artifacts from pulp server
-  pulp_artifact:
+  artifact:
     api_url: localhost:24817
     username: admin
     password: password
@@ -42,21 +42,21 @@ EXAMPLES = r'''
   debug:
     var: artifact_status
 - name: Upload a file
-  pulp_artifact:
+  artifact:
     api_url: localhost:24817
     username: admin
     password: password
     file: local_artifact.txt
     state: present
 - name: Delete an artifact by specifying a file
-  pulp_atifact:
+  artifact:
     api_url: localhost:24817
     username: admin
     password: password
     file: local_artifact.txt
     state: absent
 - name: Delete an artifact by specifying the digest
-  pulp_atifact:
+  artifact:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/delete_orphans.py
+++ b/plugins/modules/delete_orphans.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_status
-short_description: Report status of a pulp api server instance
+module: delete_orphans
+short_description: Deletes all orphaned entities of a pulp server
 description:
-  - "This module queries a pulp api server instance for installed plugins and service connectivity."
+  - "This module deletes all orphaned artifacts and content units of a pulp server."
 options: {}
 extends_documentation_fragment:
   - pulp.squeezer.pulp
@@ -22,20 +22,16 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Read status from pulp api server
-  pulp_status:
+- name: Delete orphans
+  delete_orphans:
     api_url: localhost:24817
     username: admin
     password: password
-  register: pulp_status
-- name: Report pulp status
-  debug:
-    var: pulp_status
 '''
 
 RETURN = r'''
-  status:
-    description: Pulp server status
+  summary:
+    description: Summary of deleted entities
     type: dict
     returned: always
 '''
@@ -43,14 +39,14 @@ RETURN = r'''
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import (
     PulpAnsibleModule,
-    PulpStatus,
+    PulpOrphans,
 )
 
 
 def main():
     with PulpAnsibleModule() as module:
-        status = PulpStatus(module).api.status_read()
-        module.set_result('status', status.to_dict())
+        summary = PulpOrphans(module).delete()
+        module.set_result('summary', summary)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/file_content.py
+++ b/plugins/modules/file_content.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_content
+module: file_content
 short_description: Manage file content of a pulp api server instance
 description:
   - "This performs CRUD operations on file content in a pulp api server instance."
@@ -34,7 +34,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of file content units from pulp api server
-  pulp_file_content:
+  file_content:
     api_url: localhost:24817
     username: admin
     password: password
@@ -43,7 +43,7 @@ EXAMPLES = r'''
   debug:
     var: content_status
 - name: Create a file content unit
-  pulp_file_content:
+  file_content:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/file_distribution.py
+++ b/plugins/modules/file_distribution.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_distribution
+module: file_distribution
 short_description: Manage file distributions of a pulp api server instance
 description:
   - "This performs CRUD operations on file distributions in a pulp api server instance."
@@ -45,7 +45,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of file distributions from pulp api server
-  pulp_file_distribution:
+  file_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -55,7 +55,7 @@ EXAMPLES = r'''
     var: distribution_status
 
 - name: Create a file distribution
-  pulp_file_distribution:
+  file_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -64,7 +64,7 @@ EXAMPLES = r'''
     publication: /pub/api/v3/publications/file/file/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/
     state: present
 - name: Delete a file distribution
-  pulp_file_distribution:
+  file_distribution:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/file_publication.py
+++ b/plugins/modules/file_publication.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_python_publication
-short_description: Manage python publications of a pulp api server instance
+module: file_publication
+short_description: Manage file publications of a pulp api server instance
 description:
-  - "This performs CRUD operations on python publications in a pulp api server instance."
+  - "This performs CRUD operations on file publications in a pulp api server instance."
 options:
   repository:
     description:
@@ -25,6 +25,11 @@ options:
       - Version number to be published
     type: int
     required: false
+  manifest:
+    description:
+      - Name of the pulp manifest file in the publication
+    type: str
+    required: false
 extends_documentation_fragment:
   - pulp.squeezer.pulp
   - pulp.squeezer.pulp.entity_state
@@ -33,47 +38,47 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Read list of python publications
-  pulp_python_publication:
+- name: Read list of file publications from pulp api server
+  file_publication:
     api_url: localhost:24817
     username: admin
     password: password
   register: publication_status
-- name: Report pulp python publications
+- name: Report pulp file publications
   debug:
     var: publication_status
-- name: Create a python publication
-  pulp_python_publication:
+- name: Create a file publication
+  file_publication:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: my_python_repo
+    repository: my_file_repo
     state: present
-- name: Delete a python publication
-  pulp_file_publication:
+- name: Delete a file publication
+  file_publication:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: my_python_repo
+    repository: my_file_repo
     state: absent
 '''
 
 RETURN = r'''
   publications:
-    description: List of python publications
+    description: List of file publications
     type: list
     returned: when no repository is given
   publication:
-    description: Python publication details
+    description: File publication details
     type: dict
     returned: when repository is given
 '''
 
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import PulpEntityAnsibleModule
-from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_python_helper import (
-    PulpPythonPublication,
-    PulpPythonRepository,
+from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_file_helper import (
+    PulpFilePublication,
+    PulpFileRepository,
 )
 
 
@@ -82,6 +87,7 @@ def main():
         argument_spec=dict(
             repository=dict(),
             version=dict(type='int'),
+            manifest=dict(),
         ),
         required_if=(
             ['state', 'present', ['repository']],
@@ -91,10 +97,12 @@ def main():
 
         repository_name = module.params['repository']
         version = module.params['version']
-        desired_attributes = {}
+        desired_attributes = {
+            key: module.params[key] for key in ['manifest'] if module.params[key] is not None
+        }
 
         if repository_name:
-            repository = PulpPythonRepository(module, {'name': repository_name}).find()
+            repository = PulpFileRepository(module, {'name': repository_name}).find()
             if repository is None:
                 raise Exception("Failed to find repository ({repository_name}).".format(repository_name=repository_name))
             # TODO check if version exists
@@ -106,7 +114,7 @@ def main():
         else:
             natural_key = {'repository_version': None}
 
-        PulpPythonPublication(module, natural_key, desired_attributes).process()
+        PulpFilePublication(module, natural_key, desired_attributes).process()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/file_remote.py
+++ b/plugins/modules/file_remote.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_remote
+module: file_remote
 short_description: Manage file remotes of a pulp api server instance
 description:
   - "This performs CRUD operations on file remotes in a pulp api server instance."
@@ -52,7 +52,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of file remotes from pulp api server
-  pulp_file_remote:
+  file_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -61,7 +61,7 @@ EXAMPLES = r'''
   debug:
     var: remote_status
 - name: Create a file remote
-  pulp_file_remote:
+  file_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -69,7 +69,7 @@ EXAMPLES = r'''
     url: http://localhost/pub/file/pulp_manifest
     state: present
 - name: Delete a file remote
-  pulp_file_remote:
+  file_remote:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/file_repository.py
+++ b/plugins/modules/file_repository.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_repository
+module: file_repository
 short_description: Manage file repositories of a pulp api server instance
 description:
   - "This performs CRUD operations on file repositories in a pulp api server instance."
@@ -32,7 +32,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of file repositories from pulp api server
-  pulp_file_repository:
+  file_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -41,7 +41,7 @@ EXAMPLES = r'''
   debug:
     var: repo_status
 - name: Create a file repository
-  pulp_file_repository:
+  file_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -49,7 +49,7 @@ EXAMPLES = r'''
     description: A brand new repository with a description
     state: present
 - name: Delete a file repository
-  pulp_file_repository:
+  file_repository:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/file_sync.py
+++ b/plugins/modules/file_sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# copyright (c) 2020, Matthias Dellweg
+# copyright (c) 2019, Matthias Dellweg
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_python_sync
-short_description: Synchronize a python remote on a pulp server
+module: file_sync
+short_description: Synchronize a file remote on a pulp server
 description:
-  - "This module synchronizes a python remote into a repository."
+  - "This module synchronizes a file remote into a repository."
 options:
   remote:
     description:
@@ -32,13 +32,13 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Sync python remote into repository
-  pulp_python_sync:
+- name: Sync file remote into repository
+  file_sync:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: repo_1
-    remote: remote_1
+    repository: file_repo_1
+    remote: file_remote_1
   register: sync_result
 - name: Report synched repository version
   debug:
@@ -54,9 +54,9 @@ RETURN = r'''
 
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import PulpAnsibleModule
-from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_python_helper import (
-    PulpPythonRemote,
-    PulpPythonRepository,
+from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_file_helper import (
+    PulpFileRemote,
+    PulpFileRepository
 )
 
 
@@ -68,13 +68,13 @@ def main():
         ),
     ) as module:
 
-        remote = PulpPythonRemote(module, {'name': module.params['remote']})
+        remote = PulpFileRemote(module, {'name': module.params['remote']})
         remote_entity = remote.find()
 
         if remote_entity is None:
             raise Exception("Remote '{0}' not found.".format(module.params['remote']))
 
-        repository = PulpPythonRepository(module, {'name': module.params['repository']})
+        repository = PulpFileRepository(module, {'name': module.params['repository']})
         repository_entity = repository.find()
         if repository_entity is None:
             raise Exception("Repository '{0}' not found.".format(module.params['repository']))

--- a/plugins/modules/python_distribution.py
+++ b/plugins/modules/python_distribution.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_python_distribution
+module: python_distribution
 short_description: Manage python distributions of a pulp api server instance
 description:
   - "This performs CRUD operations on python distributions in a pulp api server instance."
@@ -45,7 +45,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of python distributions
-  pulp_python_distribution:
+  python_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -55,7 +55,7 @@ EXAMPLES = r'''
     var: distribution_status
 
 - name: Create a python distribution
-  pulp_python_distribution:
+  python_distribution:
     api_url: localhost:24817
     username: admin
     password: password
@@ -65,7 +65,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Delete a python distribution
-  pulp_python_distribution:
+  python_distribution:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/python_publication.py
+++ b/plugins/modules/python_publication.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_publication
-short_description: Manage file publications of a pulp api server instance
+module: python_publication
+short_description: Manage python publications of a pulp api server instance
 description:
-  - "This performs CRUD operations on file publications in a pulp api server instance."
+  - "This performs CRUD operations on python publications in a pulp api server instance."
 options:
   repository:
     description:
@@ -25,11 +25,6 @@ options:
       - Version number to be published
     type: int
     required: false
-  manifest:
-    description:
-      - Name of the pulp manifest file in the publication
-    type: str
-    required: false
 extends_documentation_fragment:
   - pulp.squeezer.pulp
   - pulp.squeezer.pulp.entity_state
@@ -38,47 +33,47 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Read list of file publications from pulp api server
-  pulp_file_publication:
+- name: Read list of python publications
+  python_publication:
     api_url: localhost:24817
     username: admin
     password: password
   register: publication_status
-- name: Report pulp file publications
+- name: Report pulp python publications
   debug:
     var: publication_status
-- name: Create a file publication
-  pulp_file_publication:
+- name: Create a python publication
+  python_publication:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: my_file_repo
+    repository: my_python_repo
     state: present
-- name: Delete a file publication
-  pulp_file_publication:
+- name: Delete a python publication
+  file_publication:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: my_file_repo
+    repository: my_python_repo
     state: absent
 '''
 
 RETURN = r'''
   publications:
-    description: List of file publications
+    description: List of python publications
     type: list
     returned: when no repository is given
   publication:
-    description: File publication details
+    description: Python publication details
     type: dict
     returned: when repository is given
 '''
 
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import PulpEntityAnsibleModule
-from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_file_helper import (
-    PulpFilePublication,
-    PulpFileRepository,
+from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_python_helper import (
+    PulpPythonPublication,
+    PulpPythonRepository,
 )
 
 
@@ -87,7 +82,6 @@ def main():
         argument_spec=dict(
             repository=dict(),
             version=dict(type='int'),
-            manifest=dict(),
         ),
         required_if=(
             ['state', 'present', ['repository']],
@@ -97,12 +91,10 @@ def main():
 
         repository_name = module.params['repository']
         version = module.params['version']
-        desired_attributes = {
-            key: module.params[key] for key in ['manifest'] if module.params[key] is not None
-        }
+        desired_attributes = {}
 
         if repository_name:
-            repository = PulpFileRepository(module, {'name': repository_name}).find()
+            repository = PulpPythonRepository(module, {'name': repository_name}).find()
             if repository is None:
                 raise Exception("Failed to find repository ({repository_name}).".format(repository_name=repository_name))
             # TODO check if version exists
@@ -114,7 +106,7 @@ def main():
         else:
             natural_key = {'repository_version': None}
 
-        PulpFilePublication(module, natural_key, desired_attributes).process()
+        PulpPythonPublication(module, natural_key, desired_attributes).process()
 
 
 if __name__ == '__main__':

--- a/plugins/modules/python_remote.py
+++ b/plugins/modules/python_remote.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_python_remote
+module: python_remote
 short_description: Manage python remotes of a pulp api server instance
 description:
   - "This performs CRUD operations on python remotes in a pulp api server instance."
@@ -88,7 +88,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of python remotes from pulp api server
-  pulp_python_remote:
+  python_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -97,7 +97,7 @@ EXAMPLES = r'''
   debug:
     var: remote_status
 - name: Create a python remote
-  pulp_python_remote:
+  python_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -105,7 +105,7 @@ EXAMPLES = r'''
     url: https://pypi.org/
     state: present
 - name: Delete a python remote
-  pulp_python_remote:
+  python_remote:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/python_repository.py
+++ b/plugins/modules/python_repository.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_python_repository
+module: python_repository
 short_description: Manage python repositories of a pulp api server instance
 description:
   - "This performs CRUD operations on python repositories in a pulp api server instance."
@@ -32,7 +32,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of python repositories from pulp api server
-  pulp_python_repository:
+  python_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -41,7 +41,7 @@ EXAMPLES = r'''
   debug:
     var: repo_status
 - name: Create a python repository
-  pulp_python_repository:
+  python_repository:
     api_url: localhost:24817
     username: admin
     password: password
@@ -49,7 +49,7 @@ EXAMPLES = r'''
     description: A brand new repository with a description
     state: present
 - name: Delete a python repository
-  pulp_python_repository:
+  python_repository:
     api_url: localhost:24817
     username: admin
     password: password

--- a/plugins/modules/python_sync.py
+++ b/plugins/modules/python_sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# copyright (c) 2019, Matthias Dellweg
+# copyright (c) 2020, Matthias Dellweg
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_file_sync
-short_description: Synchronize a file remote on a pulp server
+module: python_sync
+short_description: Synchronize a python remote on a pulp server
 description:
-  - "This module synchronizes a file remote into a repository."
+  - "This module synchronizes a python remote into a repository."
 options:
   remote:
     description:
@@ -32,13 +32,13 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Sync file remote into repository
-  pulp_file_sync:
+- name: Sync python remote into repository
+  python_sync:
     api_url: localhost:24817
     username: admin
     password: password
-    repository: file_repo_1
-    remote: file_remote_1
+    repository: repo_1
+    remote: remote_1
   register: sync_result
 - name: Report synched repository version
   debug:
@@ -54,9 +54,9 @@ RETURN = r'''
 
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import PulpAnsibleModule
-from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_file_helper import (
-    PulpFileRemote,
-    PulpFileRepository
+from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_python_helper import (
+    PulpPythonRemote,
+    PulpPythonRepository,
 )
 
 
@@ -68,13 +68,13 @@ def main():
         ),
     ) as module:
 
-        remote = PulpFileRemote(module, {'name': module.params['remote']})
+        remote = PulpPythonRemote(module, {'name': module.params['remote']})
         remote_entity = remote.find()
 
         if remote_entity is None:
             raise Exception("Remote '{0}' not found.".format(module.params['remote']))
 
-        repository = PulpFileRepository(module, {'name': module.params['repository']})
+        repository = PulpPythonRepository(module, {'name': module.params['repository']})
         repository_entity = repository.find()
         if repository_entity is None:
             raise Exception("Repository '{0}' not found.".format(module.params['repository']))

--- a/plugins/modules/status.py
+++ b/plugins/modules/status.py
@@ -10,10 +10,10 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_delete_orphans
-short_description: Deletes all orphaned entities of a pulp server
+module: status
+short_description: Report status of a pulp api server instance
 description:
-  - "This module deletes all orphaned artifacts and content units of a pulp server."
+  - "This module queries a pulp api server instance for installed plugins and service connectivity."
 options: {}
 extends_documentation_fragment:
   - pulp.squeezer.pulp
@@ -22,16 +22,20 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Delete orphans
-  pulp_delete_orphans:
+- name: Read status from pulp api server
+  status:
     api_url: localhost:24817
     username: admin
     password: password
+  register: pulp_status
+- name: Report pulp status
+  debug:
+    var: pulp_status
 '''
 
 RETURN = r'''
-  summary:
-    description: Summary of deleted entities
+  status:
+    description: Pulp server status
     type: dict
     returned: always
 '''
@@ -39,14 +43,14 @@ RETURN = r'''
 
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp_helper import (
     PulpAnsibleModule,
-    PulpOrphans,
+    PulpStatus,
 )
 
 
 def main():
     with PulpAnsibleModule() as module:
-        summary = PulpOrphans(module).delete()
-        module.set_result('summary', summary)
+        status = PulpStatus(module).api.status_read()
+        module.set_result('status', status.to_dict())
 
 
 if __name__ == '__main__':

--- a/plugins/modules/task.py
+++ b/plugins/modules/task.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: pulp_task
+module: task
 short_description: Manage tasks of a pulp api server instance
 description:
   - "This performs list, show and cancel operations on tasks in a pulp server."
@@ -35,7 +35,7 @@ author:
 
 EXAMPLES = r'''
 - name: Read list of tasks from pulp server
-  pulp_tasks:
+  tasks:
     api_url: localhost:24817
     username: admin
     password: password
@@ -45,7 +45,7 @@ EXAMPLES = r'''
     var: task_summary
 # TODO
 - name: Create a file remote
-  pulp_file_remote:
+  file_remote:
     api_url: localhost:24817
     username: admin
     password: password
@@ -53,7 +53,7 @@ EXAMPLES = r'''
     url: http://localhost/pub/file/pulp_manifest
     state: present
 - name: Delete a file remote
-  pulp_file_remote:
+  file_remote:
     api_url: localhost:24817
     username: admin
     password: password

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pulpcore-client~=3.2.0
-pulp_ansible-client~=0.2.0b10
-pulp_file-client~=0.2.0
+pulpcore-client~=3.3.1
+pulp_ansible-client~=0.2.0b14
+pulp_file-client~=0.3.0
 pulp_python-client~=3.0.0b9
 ansible
 ansible_runner

--- a/tests/fixtures/task-0.yml
+++ b/tests/fixtures/task-0.yml
@@ -7,7 +7,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/tasks/?limit=20&offset=0
   response:
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:27 GMT
+      - Tue, 07 Jul 2020 16:05:58 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/fixtures/task-1.yml
+++ b/tests/fixtures/task-1.yml
@@ -7,16 +7,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/tasks/?limit=20&offset=0
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}]}'
     headers:
       Allow:
       - GET, HEAD, OPTIONS
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:28 GMT
+      - Tue, 07 Jul 2020 16:05:59 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/fixtures/task-2.yml
+++ b/tests/fixtures/task-2.yml
@@ -7,16 +7,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:28 GMT
+      - Tue, 07 Jul 2020 16:06:00 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/fixtures/task-3.yml
+++ b/tests/fixtures/task-3.yml
@@ -7,16 +7,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"running","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[null],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:29 GMT
+      - Tue, 07 Jul 2020 16:06:00 GMT
       Server:
       - nginx/1.14.2
       Vary:
@@ -38,33 +38,34 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"pulp_href": "/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/",
-      "pulp_created": "2020-06-27T21:07:27.380494+00:00", "state": "canceled", "name":
-      "pulp_file.app.tasks.synchronizing.synchronize", "started_at": "2020-06-27T21:07:27.469891+00:00",
-      "worker": "/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/", "progress_reports":
-      [{"message": "Downloading Artifacts", "code": "downloading.artifacts", "state":
-      "running", "done": 0}, {"message": "Associating Content", "code": "associating.content",
-      "state": "running", "done": 0}, {"message": "Downloading Metadata", "code":
-      "downloading.metadata", "state": "completed", "done": 1}, {"message": "Parsing
-      Metadata Lines", "code": "parsing.metadata", "state": "completed", "total":
-      10, "done": 10}], "created_resources": [null], "reserved_resources_record":
-      ["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/", "/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+    body: '{"pulp_href": "/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/",
+      "pulp_created": "2020-07-07T16:05:58.758799+00:00", "state": "canceled", "name":
+      "pulp_file.app.tasks.synchronizing.synchronize", "started_at": "2020-07-07T16:05:58.851169+00:00",
+      "worker": "/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/", "child_tasks":
+      [], "progress_reports": [{"message": "Downloading Metadata", "code": "downloading.metadata",
+      "state": "completed", "done": 1}, {"message": "Downloading Artifacts", "code":
+      "downloading.artifacts", "state": "running", "done": 0}, {"message": "Associating
+      Content", "code": "associating.content", "state": "running", "done": 0}, {"message":
+      "Parsing Metadata Lines", "code": "parsing.metadata", "state": "completed",
+      "total": 10, "done": 10}], "created_resources": [null], "reserved_resources_record":
+      ["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/",
+      "/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Accept:
       - application/json
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -75,7 +76,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:30 GMT
+      - Tue, 07 Jul 2020 16:06:02 GMT
       Server:
       - nginx/1.14.2
       Vary:
@@ -93,16 +94,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -113,7 +114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:31 GMT
+      - Tue, 07 Jul 2020 16:06:02 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/fixtures/task-4.yml
+++ b/tests/fixtures/task-4.yml
@@ -7,16 +7,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:31 GMT
+      - Tue, 07 Jul 2020 16:06:02 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/fixtures/task-5.yml
+++ b/tests/fixtures/task-5.yml
@@ -7,16 +7,16 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.2.1/python
+      - OpenAPI-Generator/3.3.1/python
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/763be56c-1d70-478a-b710-ad196d0b4b65/","pulp_created":"2020-06-27T21:07:27.380494Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-06-27T21:07:27.469891Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/8b341052-0432-46c3-80f4-34d4e92ac585/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+      string: '{"pulp_href":"/pulp/api/v3/tasks/b2b9a882-8789-40e5-8ab3-f5702f7cebe4/","pulp_created":"2020-07-07T16:05:58.758799Z","state":"canceled","name":"pulp_file.app.tasks.synchronizing.synchronize","started_at":"2020-07-07T16:05:58.851169Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/ed0e304d-a974-43a4-a1f5-47a85204bc07/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Downloading
+        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Downloading
         Artifacts","code":"downloading.artifacts","state":"running","total":null,"done":0,"suffix":null},{"message":"Associating
-        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Downloading
-        Metadata","code":"downloading.metadata","state":"completed","total":null,"done":1,"suffix":null},{"message":"Parsing
-        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/remotes/file/file/668c9510-3139-4bff-bc82-a7af8fd3ab54/","/pulp/api/v3/repositories/file/file/003712b5-4385-44e7-ab11-1ebd9b604453/"]}'
+        Content","code":"associating.content","state":"running","total":null,"done":0,"suffix":null},{"message":"Parsing
+        Metadata Lines","code":"parsing.metadata","state":"completed","total":10,"done":10,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/file/file/dd89d36d-9400-42af-8836-e7210e93155f/","/pulp/api/v3/remotes/file/file/c93073db-9d76-456e-9807-8a7ebe746945/"]}'
     headers:
       Allow:
       - GET, PATCH, DELETE, HEAD, OPTIONS
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 27 Jun 2020 21:07:31 GMT
+      - Tue, 07 Jul 2020 16:06:03 GMT
       Server:
       - nginx/1.14.2
       Vary:

--- a/tests/playbooks/ansible_distribution.yaml
+++ b/tests/playbooks/ansible_distribution.yaml
@@ -6,32 +6,32 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_ansible_distribution: &pulp_connection_details
+    ansible_distribution: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_ansible_remote:
+    ansible_remote:
       <<: *pulp_connection_details
-    pulp_ansible_sync:
+    ansible_sync:
       <<: *pulp_connection_details
-    pulp_ansible_repository:
+    ansible_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
     - name: Make repository present
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: present
     - name: Make remote present
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=ansible"
         state: present
     - name: Sync remote into repository
-      pulp_ansible_sync:
+      ansible_sync:
         remote: test_ansible_remote
         repository: test_ansible_repository
 
@@ -45,12 +45,12 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Retrieve repository information
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
       register: repository_result
 
     - name: Distribute latest version of repository
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         base_path: test_ansible_base_path
         repository: test_ansible_repository
@@ -66,7 +66,7 @@
           - result.distribution.repository == repository_result.repository.pulp_href
 
     - name: Distribute latest version of repository (2nd try)
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         base_path: test_ansible_base_path
         repository: test_ansible_repository
@@ -78,7 +78,7 @@
           - result.changed == false
 
     - name: Read distribution
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
       register: result
     - name: Verify read distribution
@@ -92,7 +92,7 @@
           - result.distribution.repository_version == None
 
     - name: Delete distribution
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         state: absent
       register: result
@@ -103,7 +103,7 @@
           - not result.distribution
 
     - name: Delete distribution (2nd try)
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         state: absent
       register: result
@@ -113,7 +113,7 @@
           - result.changed == false
 
     - name: Distribute specific version of repository
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         base_path: test_ansible_base_path
         repository: test_ansible_repository
@@ -131,7 +131,7 @@
           - result.distribution.repository_version == repository_result.repository.versions_href + '1/'
 
     - name: Distribute specific version of repository (2nd try)
-      pulp_ansible_distribution:
+      ansible_distribution:
         name: test_ansible_distribution
         base_path: test_ansible_base_path
         repository: test_ansible_repository
@@ -153,11 +153,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
     - name: Make ansible_remote absent
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         state: absent
 ...

--- a/tests/playbooks/ansible_remote.yaml
+++ b/tests/playbooks/ansible_remote.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_ansible_remote: &pulp_connection_details
+    ansible_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make remote absent
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create remote
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=ansible"
         proxy_url: "http://proxy.int:3128"
@@ -41,7 +41,7 @@
           - result.remote.proxy_url == "http://proxy.int:3128"
 
     - name: Create remote (2nd try)
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=ansible"
         proxy_url: "http://proxy.int:3128"
@@ -53,7 +53,7 @@
           - result.changed == false
 
     - name: Modify remote
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=pulp"
         tls_validation: false
@@ -67,7 +67,7 @@
           - result.remote.tls_validation == false
 
     - name: Modify remote (2nd try)
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=pulp"
         tls_validation: false
@@ -79,7 +79,7 @@
           - result.changed == false
 
     - name: List remotes
-      pulp_ansible_remote: {}
+      ansible_remote: {}
       register: result
     - name: Verify list remotes
       assert:
@@ -89,7 +89,7 @@
           - result.remotes | selectattr('name', 'match', 'test_ansible_remote') | list | length == 1
 
     - name: Read remote
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
       register: result
     - name: Verify read remote
@@ -103,7 +103,7 @@
           - result.remote.tls_validation == false
 
     - name: Delete remote
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         state: absent
       register: result
@@ -114,7 +114,7 @@
           - not result.remote
 
     - name: Delete remote (2nd try)
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         state: absent
       register: result

--- a/tests/playbooks/ansible_repository.yaml
+++ b/tests/playbooks/ansible_repository.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_ansible_repository: &pulp_connection_details
+    ansible_repository: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make repository absent
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         description: ""
         state: present
@@ -38,7 +38,7 @@
           - result.repository.name == 'test_ansible_repository'
 
     - name: Create repository (2nd try)
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: present
       register: result
@@ -48,7 +48,7 @@
           - result.changed == false
 
     - name: Add description to repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         description: "repository created via ansible"
         state: present
@@ -60,7 +60,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: Add description to repository (2nd try)
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         description: "repository created via ansible"
         state: present
@@ -71,7 +71,7 @@
           - result.changed == false
 
     - name: Fake modify repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: present
       register: result
@@ -82,7 +82,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: List repositories
-      pulp_ansible_repository: {}
+      ansible_repository: {}
       register: result
     - name: Verify list repositories
       assert:
@@ -91,7 +91,7 @@
           - result.repositories | length >= 1
 
     - name: Read repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
       register: result
     - name: Verify read repository
@@ -105,7 +105,7 @@
       when: false
       block:
         - name: Remove description from repository
-          pulp_ansible_repository:
+          ansible_repository:
             name: test_ansible_repository
             description: ""
             state: present
@@ -117,7 +117,7 @@
               - not result.repository.description
 
         - name: Remove description from repository (2nd try)
-          pulp_ansible_repository:
+          ansible_repository:
             name: test_ansible_repository
             description: ""
             state: present
@@ -128,7 +128,7 @@
               - result.changed == false
 
     - name: Delete repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
       register: result
@@ -139,7 +139,7 @@
           - not result.repository
 
     - name: Delete repository (2nd try)
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
       register: result

--- a/tests/playbooks/ansible_role.yaml
+++ b/tests/playbooks/ansible_role.yaml
@@ -8,19 +8,19 @@
   vars:
     file1_sha256: "{{ lookup('file', 'data/file1.txt', lstrip=false, rstrip=false) | hash('sha256') }}"
   module_defaults: &pulp_module_defaults
-    pulp_artifact: &pulp_connection_details
+    artifact: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_ansible_role:
+    ansible_role:
       <<: *pulp_connection_details
-    pulp_delete_orphans:
+    delete_orphans:
       <<: *pulp_connection_details
   tasks:
     - name: Delete orphaned objects
-      pulp_delete_orphans: {}
+      delete_orphans: {}
     - name: Create artifact
-      pulp_artifact:
+      artifact:
         file: data/file1.txt
         state: present
 
@@ -36,11 +36,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Search artifact
-      pulp_artifact:
+      artifact:
         sha256: "{{ file1_sha256 }}"
       register: artifact_result
     - name: Create ansible role
-      pulp_ansible_role:
+      ansible_role:
         name: test_ansible_role
         namespace: test_namespace
         version: 0.0.0
@@ -55,7 +55,7 @@
           - result.content.namespace == "test_namespace"
 
     - name: Create ansible role (2nd try)
-      pulp_ansible_role:
+      ansible_role:
         name: test_ansible_role
         namespace: test_namespace
         version: 0.0.0
@@ -68,7 +68,7 @@
           - result.changed == false
 
     - name: List ansible roles
-      pulp_ansible_role: {}
+      ansible_role: {}
       register: result
     - name: Verify list ansible roles
       assert:
@@ -77,7 +77,7 @@
           - result.contents | length >= 1
 
     - name: Read ansible role
-      pulp_ansible_role:
+      ansible_role:
         name: test_ansible_role
         namespace: test_namespace
         version: 0.0.0

--- a/tests/playbooks/ansible_sync.yaml
+++ b/tests/playbooks/ansible_sync.yaml
@@ -6,25 +6,25 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_ansible_remote: &pulp_connection_details
+    ansible_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_ansible_sync:
+    ansible_sync:
       <<: *pulp_connection_details
-    pulp_ansible_repository:
+    ansible_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
     - name: Make repository present
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: present
     - name: Make remote present
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         url: "https://galaxy.ansible.com/api/v1/roles/?namespace__name=ansible"
         state: present
@@ -39,7 +39,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Sync remote into repository
-      pulp_ansible_sync:
+      ansible_sync:
         remote: test_ansible_remote
         repository: test_ansible_repository
       register: result
@@ -50,7 +50,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/ansible/ansible/.*/versions/1/")
 
     - name: Sync remote into repository (2nd try)
-      pulp_ansible_sync:
+      ansible_sync:
         remote: test_ansible_remote
         repository: test_ansible_repository
       register: result
@@ -61,7 +61,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/ansible/ansible/.*/versions/1/")
 
     - name: Dump repository
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
       register: result
     - name: Verify repository_version in repository
@@ -79,11 +79,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_ansible_repository:
+      ansible_repository:
         name: test_ansible_repository
         state: absent
     - name: Make ansible_remote absent
-      pulp_ansible_remote:
+      ansible_remote:
         name: test_ansible_remote
         state: absent
 ...

--- a/tests/playbooks/artifact.yaml
+++ b/tests/playbooks/artifact.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_artifact: &pulp_connection_details
+    artifact: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make artifact absent
-      pulp_artifact:
+      artifact:
         file: "{{ item }}"
         state: absent
       loop:
@@ -31,7 +31,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create artifact by file
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         state: present
       register: result
@@ -42,7 +42,7 @@
           - result.artifact.sha256 == artifact_sha256
 
     - name: Create artifact by file (2nd try)
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         state: present
       register: result
@@ -52,7 +52,7 @@
           - result.changed == false
 
     - name: List artifacts
-      pulp_artifact: {}
+      artifact: {}
       register: result
     - name: Verify list artifacts
       assert:
@@ -61,7 +61,7 @@
           - result.artifacts | length >= 1
 
     - name: Read artifact by file
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
       register: result
     - name: Verify read artifact by file
@@ -71,7 +71,7 @@
           - result.artifact.sha256 == artifact_sha256
 
     - name: Read artifact by sha256
-      pulp_artifact:
+      artifact:
         sha256: "{{ artifact_sha256 }}"
       register: result
     - name: Verify read artifact by sha256
@@ -81,7 +81,7 @@
           - result.artifact.sha256 == artifact_sha256
 
     - name: Delete artifact by file
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         state: absent
       register: result
@@ -92,7 +92,7 @@
           - not result.artifact
 
     - name: Delete artifact by file (2nd try)
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         state: absent
       register: result
@@ -102,7 +102,7 @@
           - result.changed == false
 
     - name: Create artifact with sha256
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         sha256: "{{ artifact_sha256 }}"
         state: present
@@ -114,7 +114,7 @@
           - result.artifact.sha256 == artifact_sha256
 
     - name: Create artifact with sha256 (2nd try)
-      pulp_artifact:
+      artifact:
         file: data/small_artifact.dat
         sha256: "{{ artifact_sha256 }}"
         state: present
@@ -125,7 +125,7 @@
           - result.changed == false
 
     - name: Delete artifact by sha256
-      pulp_artifact:
+      artifact:
         sha256: "{{ artifact_sha256 }}"
         state: absent
       register: result
@@ -136,7 +136,7 @@
           - not result.artifact
 
     - name: Delete artifact by sha256 (2nd try)
-      pulp_artifact:
+      artifact:
         sha256: "{{ artifact_sha256 }}"
         state: absent
       register: result
@@ -146,7 +146,7 @@
           - result.changed == false
 
     - name: Create artifact with chunked upload
-      pulp_artifact:
+      artifact:
         file: data/large_artifact.dat
         state: present
       register: result
@@ -156,7 +156,7 @@
           - result.changed == true
 
     - name: Create artifact with chunked upload (2nd try)
-      pulp_artifact:
+      artifact:
         file: data/large_artifact.dat
         state: present
       register: result

--- a/tests/playbooks/delete_orphans.yaml
+++ b/tests/playbooks/delete_orphans.yaml
@@ -6,24 +6,24 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_delete_orphans: &pulp_connection_details
+    delete_orphans: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_artifact:
+    artifact:
       <<: *pulp_connection_details
-    pulp_file_content:
+    file_content:
       <<: *pulp_connection_details
   tasks:
     - name: Delete orphans
-      pulp_delete_orphans: {}
+      delete_orphans: {}
     - name: Create artifact
-      pulp_artifact:
+      artifact:
         file: data/file1.txt
         state: present
       register: result
     - name: Create file content unit
-      pulp_file_content:
+      file_content:
         digest: "{{ result.artifact.sha256 }}"
         relative_path: "data/file1.txt"
         state: present
@@ -40,7 +40,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Delete orphans
-      pulp_delete_orphans: {}
+      delete_orphans: {}
       register: orphans
     - name: Verify result
       assert:
@@ -50,7 +50,7 @@
           - orphans.summary.content == 1 or ansible_check_mode
 
     - name: Delete orphans
-      pulp_delete_orphans: {}
+      delete_orphans: {}
       register: orphans
     - name: Verify result
       assert:

--- a/tests/playbooks/file_content.yaml
+++ b/tests/playbooks/file_content.yaml
@@ -8,15 +8,15 @@
   vars:
     file1_sha256: "{{ lookup('file', 'data/file1.txt', lstrip=false, rstrip=false) | hash('sha256') }}"
   module_defaults: &pulp_module_defaults
-    pulp_artifact: &pulp_connection_details
+    artifact: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_file_content:
+    file_content:
       <<: *pulp_connection_details
   tasks:
     - name: Create artifact
-      pulp_artifact:
+      artifact:
         file: data/file1.txt
         state: present
 
@@ -32,7 +32,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create file content unit
-      pulp_file_content:
+      file_content:
         digest: "{{ file1_sha256 }}"
         relative_path: "data/file1.txt"
         state: present
@@ -45,7 +45,7 @@
           - result.content.sha256 == file1_sha256 or ansible_check_mode
 
     - name: Create file content unit (2nd try)
-      pulp_file_content:
+      file_content:
         digest: "{{ file1_sha256 }}"
         relative_path: "data/file1.txt"
         state: present
@@ -56,7 +56,7 @@
           - result.changed == false
 
     - name: List file content units
-      pulp_file_content: {}
+      file_content: {}
       register: result
     - name: Verify list file content units
       assert:
@@ -65,7 +65,7 @@
           - result.contents | length >= 1
 
     - name: Read file content unit
-      pulp_file_content:
+      file_content:
         digest: "{{ file1_sha256 }}"
         relative_path: "data/file1.txt"
       register: result

--- a/tests/playbooks/file_distribution.yaml
+++ b/tests/playbooks/file_distribution.yaml
@@ -6,42 +6,42 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_distribution: &pulp_connection_details
+    file_distribution: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_file_publication:
+    file_publication:
       <<: *pulp_connection_details
-    pulp_file_remote:
+    file_remote:
       <<: *pulp_connection_details
-    pulp_file_sync:
+    file_sync:
       <<: *pulp_connection_details
-    pulp_file_repository:
+    file_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make distribution absent
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         state: absent
     - name: Make repository present
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
     - name: Make remote present
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "{{ pulp_fixtures_url }}/file/PULP_MANIFEST"
         state: present
     - name: Sync remote into repository
-      pulp_file_sync:
+      file_sync:
         remote: test_file_remote
         repository: test_file_repository
     - name: Publish latest version of repository
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         state: present
 
@@ -55,12 +55,12 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Retrieve publication of repository
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
       register: publication_result
 
     - name: Distribute publication of repository
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         base_path: test_file_base_path
         publication: "{{ publication_result.publication.pulp_href }}"
@@ -76,7 +76,7 @@
           - result.distribution.publication == publication_result.publication.pulp_href
 
     - name: Distribute publication of repository (2nd try)
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         base_path: test_file_base_path
         publication: "{{ publication_result.publication.pulp_href }}"
@@ -88,7 +88,7 @@
           - result.changed == false
 
     - name: Read distribution
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
       register: result
     - name: Verify read distribution
@@ -101,7 +101,7 @@
           - result.distribution.publication == publication_result.publication.pulp_href
 
     - name: Delete distribution
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         state: absent
       register: result
@@ -112,7 +112,7 @@
           - not result.distribution
 
     - name: Delete distribution (2nd try)
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         state: absent
       register: result
@@ -131,15 +131,15 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make file_remote absent
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
     - name: Make distribution absent
-      pulp_file_distribution:
+      file_distribution:
         name: test_file_distribution
         state: absent
 ...

--- a/tests/playbooks/file_publication.yaml
+++ b/tests/playbooks/file_publication.yaml
@@ -6,32 +6,32 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_publication: &pulp_connection_details
+    file_publication: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_file_remote:
+    file_remote:
       <<: *pulp_connection_details
-    pulp_file_sync:
+    file_sync:
       <<: *pulp_connection_details
-    pulp_file_repository:
+    file_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make repository present
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
     - name: Make remote present
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "{{ pulp_fixtures_url }}/file/PULP_MANIFEST"
         state: present
     - name: Sync remote into repository
-      pulp_file_sync:
+      file_sync:
         remote: test_file_remote
         repository: test_file_repository
 
@@ -45,7 +45,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Publish latest version of repository
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         state: present
       register: result
@@ -57,7 +57,7 @@
           - result.publication.manifest == "PULP_MANIFEST"
 
     - name: Publish latest version of repository (2nd try)
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         state: present
       register: result
@@ -67,7 +67,7 @@
           - result.changed == false
 
     - name: Publish latest version of repository via version number
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         version: 1
         state: present
@@ -78,7 +78,7 @@
           - result.changed == false
 
     - name: List publications
-      pulp_file_publication: {}
+      file_publication: {}
       register: result
     - name: Verify list publications
       assert:
@@ -87,7 +87,7 @@
           - result.publications | length >= 1
 
     - name: Query publication of latest version of repository
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
       register: result
     - name: Verify query publication of latest version of repository
@@ -98,7 +98,7 @@
           - result.publication.manifest == "PULP_MANIFEST"
 
     - name: Delete publication of latest version of repository
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         state: absent
       register: result
@@ -109,7 +109,7 @@
           - not result.publication
 
     - name: Delete publication of latest version of repository (2nd try)
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         state: absent
       register: result
@@ -119,7 +119,7 @@
           - result.changed == false
 
     - name: Publish latest version of repository with different manifest
-      pulp_file_publication:
+      file_publication:
         repository: test_file_repository
         manifest: "LISTING"
         state: present
@@ -142,11 +142,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make remote absent
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
 ...

--- a/tests/playbooks/file_remote.yaml
+++ b/tests/playbooks/file_remote.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_remote: &pulp_connection_details
+    file_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make file_remote absent
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create file_remote
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "https://example.org/file/PULP_MANIFEST"
         proxy_url: "http://proxy.int:3128"
@@ -41,7 +41,7 @@
           - result.remote.proxy_url == "http://proxy.int:3128"
 
     - name: Create file_remote (2nd try)
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "https://example.org/file/PULP_MANIFEST"
         proxy_url: "http://proxy.int:3128"
@@ -53,7 +53,7 @@
           - result.changed == false
 
     - name: Modify file_remote
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         policy: streamed
         tls_validation: false
@@ -67,7 +67,7 @@
           - result.remote.tls_validation == false
 
     - name: Modify file_remote (2nd try)
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         policy: streamed
         tls_validation: false
@@ -79,7 +79,7 @@
           - result.changed == false
 
     - name: List file remotes
-      pulp_file_remote: {}
+      file_remote: {}
       register: result
     - name: Verify list file remotes
       assert:
@@ -89,7 +89,7 @@
           - result.remotes | selectattr('name', 'match', 'test_file_remote') | list | length == 1
 
     - name: Read file_remote
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
       register: result
     - name: Verify read file_remote
@@ -102,7 +102,7 @@
           - result.remote.tls_validation == false
 
     - name: Delete file_remote
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
       register: result
@@ -113,7 +113,7 @@
           - not result.remote
 
     - name: Delete file_remote (2nd try)
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
       register: result

--- a/tests/playbooks/file_repository.yaml
+++ b/tests/playbooks/file_repository.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_repository: &pulp_connection_details
+    file_repository: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         description: ""
         state: present
@@ -38,7 +38,7 @@
           - result.repository.name == 'test_file_repository'
 
     - name: Create repository (2nd try)
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
       register: result
@@ -48,7 +48,7 @@
           - result.changed == false
 
     - name: Add description to repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         description: "repository created via ansible"
         state: present
@@ -60,7 +60,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: Add description to repository (2nd try)
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         description: "repository created via ansible"
         state: present
@@ -71,7 +71,7 @@
           - result.changed == false
 
     - name: Fake modify repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
       register: result
@@ -82,7 +82,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: List repositories
-      pulp_file_repository: {}
+      file_repository: {}
       register: result
     - name: Verify list repositories
       assert:
@@ -91,7 +91,7 @@
           - result.repositories | length >= 1
 
     - name: Read repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
       register: result
     - name: Verify read repository
@@ -105,7 +105,7 @@
       when: false
       block:
         - name: Remove description from repository
-          pulp_file_repository:
+          file_repository:
             name: test_file_repository
             description: ""
             state: present
@@ -117,7 +117,7 @@
               - not result.repository.description
 
         - name: Remove description from repository (2nd try)
-          pulp_file_repository:
+          file_repository:
             name: test_file_repository
             description: ""
             state: present
@@ -128,7 +128,7 @@
               - result.changed == false
 
     - name: Delete repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
       register: result
@@ -139,7 +139,7 @@
           - not result.repository
 
     - name: Delete repository (2nd try)
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
       register: result

--- a/tests/playbooks/file_sync.yaml
+++ b/tests/playbooks/file_sync.yaml
@@ -6,25 +6,25 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_remote: &pulp_connection_details
+    file_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_file_sync:
+    file_sync:
       <<: *pulp_connection_details
-    pulp_file_repository:
+    file_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make repository present
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
     - name: Make file_remote present
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "{{ pulp_fixtures_url }}/file/PULP_MANIFEST"
         state: present
@@ -39,7 +39,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Sync file_remote into repository
-      pulp_file_sync:
+      file_sync:
         remote: test_file_remote
         repository: test_file_repository
       register: result
@@ -50,7 +50,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/file/file/.*/versions/1/")
 
     - name: Sync file_remote into repository (2nd try)
-      pulp_file_sync:
+      file_sync:
         remote: test_file_remote
         repository: test_file_repository
       register: result
@@ -61,7 +61,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/file/file/.*/versions/1/")
 
     - name: Dump repository
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
       register: result
     - name: Verify repository_version in repository
@@ -79,11 +79,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make file_remote absent
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
 ...

--- a/tests/playbooks/python_distribution.yaml
+++ b/tests/playbooks/python_distribution.yaml
@@ -6,44 +6,44 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_python_distribution: &pulp_connection_details
+    python_distribution: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_python_publication:
+    python_publication:
       <<: *pulp_connection_details
-    pulp_python_remote:
+    python_remote:
       <<: *pulp_connection_details
-    pulp_python_sync:
+    python_sync:
       <<: *pulp_connection_details
-    pulp_python_repository:
+    python_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make distribution absent
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         state: absent
     - name: Make repository present
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: present
     - name: Make remote present
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         url: "{{ pulp_fixtures_url }}/python-pypi/"
         includes:
           - name: shelf-reader
         state: present
     - name: Sync remote into repository
-      pulp_python_sync:
+      python_sync:
         remote: test_python_remote
         repository: test_python_repository
     - name: Publish latest version of repository
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         state: present
 
@@ -57,12 +57,12 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Retrieve publication of repository
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
       register: publication_result
 
     - name: Distribute publication of repository
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         base_path: test_python_base_path
         publication: "{{ publication_result.publication.pulp_href }}"
@@ -78,7 +78,7 @@
           - result.distribution.publication == publication_result.publication.pulp_href
 
     - name: Distribute publication of repository (2nd try)
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         base_path: test_python_base_path
         publication: "{{ publication_result.publication.pulp_href }}"
@@ -90,7 +90,7 @@
           - result.changed == false
 
     - name: Read distribution
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
       register: result
     - name: Verify read distribution
@@ -103,7 +103,7 @@
           - result.distribution.publication == publication_result.publication.pulp_href
 
     - name: Delete distribution
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         state: absent
       register: result
@@ -114,7 +114,7 @@
           - not result.distribution
 
     - name: Delete distribution (2nd try)
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         state: absent
       register: result
@@ -133,15 +133,15 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make file_remote absent
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
     - name: Make distribution absent
-      pulp_python_distribution:
+      python_distribution:
         name: test_python_distribution
         state: absent
 ...

--- a/tests/playbooks/python_publication.yaml
+++ b/tests/playbooks/python_publication.yaml
@@ -6,34 +6,34 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_python_publication: &pulp_connection_details
+    python_publication: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_python_remote:
+    python_remote:
       <<: *pulp_connection_details
-    pulp_python_sync:
+    python_sync:
       <<: *pulp_connection_details
-    pulp_python_repository:
+    python_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make repository present
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: present
     - name: Make remote present
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         url: "{{ pulp_fixtures_url }}/python-pypi/"
         includes:
           - name: shelf-reader
         state: present
     - name: Sync remote into repository
-      pulp_python_sync:
+      python_sync:
         remote: test_python_remote
         repository: test_python_repository
 
@@ -47,7 +47,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Publish latest version of repository
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         state: present
       register: result
@@ -58,7 +58,7 @@
           - result.publication.repository_version is match("/pulp/api/v3/repositories/.*/versions/1/")
 
     - name: Publish latest version of repository (2nd try)
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         state: present
       register: result
@@ -68,7 +68,7 @@
           - result.changed == false
 
     - name: Publish latest version of repository via version number
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         version: 1
         state: present
@@ -79,7 +79,7 @@
           - result.changed == false
 
     - name: List publications
-      pulp_python_publication: {}
+      python_publication: {}
       register: result
     - name: Verify list publications
       assert:
@@ -88,7 +88,7 @@
           - result.publications | length >= 1
 
     - name: Query publication of latest version of repository
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
       register: result
     - name: Verify query publication of latest version of repository
@@ -98,7 +98,7 @@
           - result.publication.repository_version is match("/pulp/api/v3/repositories/.*/versions/1/")
 
     - name: Delete publication of latest version of repository
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         state: absent
       register: result
@@ -109,7 +109,7 @@
           - not result.publication
 
     - name: Delete publication of latest version of repository (2nd try)
-      pulp_python_publication:
+      python_publication:
         repository: test_python_repository
         state: absent
       register: result
@@ -128,11 +128,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make remote absent
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
 ...

--- a/tests/playbooks/python_remote.yaml
+++ b/tests/playbooks/python_remote.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_python_remote: &pulp_connection_details
+    python_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make python_remote absent
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create remote
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         url: "https://pypi.org/"
         proxy_url: "http://proxy.int:3128"
@@ -41,7 +41,7 @@
           - result.remote.proxy_url == "http://proxy.int:3128"
 
     - name: Create remote (2nd try)
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         url: "https://pypi.org/"
         proxy_url: "http://proxy.int:3128"
@@ -53,7 +53,7 @@
           - result.changed == false
 
     - name: Modify remote
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         policy: streamed
         tls_validation: false
@@ -78,7 +78,7 @@
           - result.remote.excludes[0].name == "cccc"
 
     - name: Modify remote (2nd try)
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         policy: streamed
         tls_validation: false
@@ -97,7 +97,7 @@
           - result.changed == false
 
     - name: List remotes
-      pulp_python_remote: {}
+      python_remote: {}
       register: result
     - name: Verify list remotes
       assert:
@@ -107,7 +107,7 @@
           - result.remotes | selectattr('name', 'match', 'test_python_remote') | list | length == 1
 
     - name: Read remote
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
       register: result
     - name: Verify read remote
@@ -120,7 +120,7 @@
           - result.remote.tls_validation == false
 
     - name: Delete remote
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
       register: result
@@ -131,7 +131,7 @@
           - not result.remote
 
     - name: Delete remote (2nd try)
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
       register: result

--- a/tests/playbooks/python_repository.yaml
+++ b/tests/playbooks/python_repository.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_python_repository: &pulp_connection_details
+    python_repository: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
 
@@ -26,7 +26,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Create repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         description: ""
         state: present
@@ -38,7 +38,7 @@
           - result.repository.name == 'test_python_repository'
 
     - name: Create repository (2nd try)
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: present
       register: result
@@ -48,7 +48,7 @@
           - result.changed == false
 
     - name: Add description to repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         description: "repository created via ansible"
         state: present
@@ -60,7 +60,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: Add description to repository (2nd try)
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         description: "repository created via ansible"
         state: present
@@ -71,7 +71,7 @@
           - result.changed == false
 
     - name: Fake modify repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: present
       register: result
@@ -82,7 +82,7 @@
           - result.repository.description == "repository created via ansible"
 
     - name: List repositories
-      pulp_python_repository: {}
+      python_repository: {}
       register: result
     - name: Verify list repositories
       assert:
@@ -91,7 +91,7 @@
           - result.repositories | length >= 1
 
     - name: Read repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
       register: result
     - name: Verify read repository
@@ -105,7 +105,7 @@
       when: false
       block:
         - name: Remove description from repository
-          pulp_python_repository:
+          python_repository:
             name: test_python_repository
             description: ""
             state: present
@@ -117,7 +117,7 @@
               - not result.repository.description
 
         - name: Remove description from repository (2nd try)
-          pulp_python_repository:
+          python_repository:
             name: test_python_repository
             description: ""
             state: present
@@ -128,7 +128,7 @@
               - result.changed == false
 
     - name: Delete repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
       register: result
@@ -139,7 +139,7 @@
           - not result.repository
 
     - name: Delete repository (2nd try)
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
       register: result

--- a/tests/playbooks/python_sync.yaml
+++ b/tests/playbooks/python_sync.yaml
@@ -6,25 +6,25 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_python_remote: &pulp_connection_details
+    python_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_python_sync:
+    python_sync:
       <<: *pulp_connection_details
-    pulp_python_repository:
+    python_repository:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make repository present
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: present
     - name: Make remote present
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         url: "{{ pulp_fixtures_url }}/python-pypi/"
         includes:
@@ -41,7 +41,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Sync remote into repository
-      pulp_python_sync:
+      python_sync:
         remote: test_python_remote
         repository: test_python_repository
       register: result
@@ -52,7 +52,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/python/python/.*/versions/1/")
 
     - name: Sync remote into repository (2nd try)
-      pulp_python_sync:
+      python_sync:
         remote: test_python_remote
         repository: test_python_repository
       register: result
@@ -63,7 +63,7 @@
           - result.repository_version is match("/pulp/api/v3/repositories/python/python/.*/versions/1/")
 
     - name: Dump repository
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
       register: result
     - name: Verify repository_version in repository
@@ -81,11 +81,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_python_repository:
+      python_repository:
         name: test_python_repository
         state: absent
     - name: Make remote absent
-      pulp_python_remote:
+      python_remote:
         name: test_python_remote
         state: absent
 ...

--- a/tests/playbooks/status.yaml
+++ b/tests/playbooks/status.yaml
@@ -6,13 +6,13 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_status: &pulp_connection_details
+    status: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
   tasks:
     - name: Query pulp status
-      pulp_status: {}
+      status: {}
       register: pulp_status
     - name: Verify result
       assert:

--- a/tests/playbooks/task.yaml
+++ b/tests/playbooks/task.yaml
@@ -6,45 +6,45 @@
   vars_files:
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
-    pulp_file_remote: &pulp_connection_details
+    file_remote: &pulp_connection_details
       pulp_url: "{{ pulp_url }}"
       username: "{{ pulp_username }}"
       password: "{{ pulp_password }}"
-    pulp_file_sync:
+    file_sync:
       <<: *pulp_connection_details
-    pulp_file_repository:
+    file_repository:
       <<: *pulp_connection_details
-    pulp_task:
+    task:
       <<: *pulp_connection_details
-    pulp_delete_orphans:
+    delete_orphans:
       <<: *pulp_connection_details
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Delete remaining artifacts and content
-      pulp_delete_orphans: {}
+      delete_orphans: {}
     - name: Make repository present
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: present
     - name: Make remote present
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         url: "{{ pulp_fixtures_url }}/file-large/PULP_MANIFEST"
         download_concurrency: 1
         state: present
     - name: List all tasks
-      pulp_task: {}
+      task: {}
       register: result
     - name: Delete all tasks
-      pulp_task:
+      task:
         pulp_href: "{{ item.pulp_href }}"
         state: absent
       loop: "{{ result.tasks }}"
     - name: Sync remote into repository (async)
-      pulp_file_sync:
+      file_sync:
         remote: test_file_remote
         repository: test_file_repository
       register: sync_task
@@ -61,7 +61,7 @@
     <<: *pulp_module_defaults
   tasks:
     - name: List tasks
-      pulp_task: {}
+      task: {}
       register: result
       until: result.tasks | length == 1
       retries: 5
@@ -75,7 +75,7 @@
         task_href: "{{ result.tasks[0].pulp_href }}"
 
     - name: Show task
-      pulp_task:
+      task:
         pulp_href: "{{ task_href }}"
       register: result
     - name: Verify show task
@@ -87,7 +87,7 @@
           - result.task.state == "running"
 
     - name: Cancel task
-      pulp_task:
+      task:
         pulp_href: "{{ task_href }}"
         state: canceled
       register: result
@@ -99,7 +99,7 @@
           - result.task.state == "canceled"
 
     - name: Cancel task(2nd try)
-      pulp_task:
+      task:
         pulp_href: "{{ task_href }}"
         state: canceled
       register: result
@@ -111,7 +111,7 @@
           - result.task.state == "canceled"
 
     - name: Wait for canceld task
-      pulp_task:
+      task:
         pulp_href: "{{ task_href }}"
         state: completed
       register: result
@@ -132,11 +132,11 @@
     <<: *pulp_module_defaults
   tasks:
     - name: Make repository absent
-      pulp_file_repository:
+      file_repository:
         name: test_file_repository
         state: absent
     - name: Make remote absent
-      pulp_file_remote:
+      file_remote:
         name: test_file_remote
         state: absent
 ...


### PR DESCRIPTION
As the modules are namespaced by the collection, there is no need to repeat
`pulp` in all module names.