### PR TITLE
Fix typo in module name

### DIFF
--- a/plugins/modules/rpm_publication.py
+++ b/plugins/modules/rpm_publication.py
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     repository: my_rpm_repo
     state: present
 - name: Delete a rpm publication
-  file_publication:
+  rpm_publication:
     api_url: localhost:24817
     username: admin
     password: password


### PR DESCRIPTION
Rename `file_publication` to `rpm_publication` in `rpm_publication` module examples.