### PR TITLE
doc: EXAMPLES replace `api_url` with `pulp_url`

### DIFF
--- a/plugins/modules/access_policy.py
+++ b/plugins/modules/access_policy.py
@@ -76,7 +76,7 @@ author:
 EXAMPLES = r"""
 - name: Dump all access policies
   access_policy:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: access_policies_status
@@ -86,7 +86,7 @@ EXAMPLES = r"""
 
 - name: View the access policy for tasks
   access_policy:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     viewset_name: "tasks"
@@ -97,7 +97,7 @@ EXAMPLES = r"""
 
 - name: Modify the access policy for tasks
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     viewset_name: "tasks"

--- a/plugins/modules/ansible_distribution.py
+++ b/plugins/modules/ansible_distribution.py
@@ -53,7 +53,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of ansible distributions from pulp api server
   ansible_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: distribution_status
@@ -63,7 +63,7 @@ EXAMPLES = r"""
 
 - name: Create an ansible distribution
   ansible_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_ansible_distribution
@@ -73,7 +73,7 @@ EXAMPLES = r"""
 
 - name: Delete an ansible distribution
   ansible_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_ansible_distribution

--- a/plugins/modules/ansible_remote.py
+++ b/plugins/modules/ansible_remote.py
@@ -60,7 +60,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of ansible remotes from pulp api server
   ansible_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: remote_status
@@ -69,7 +69,7 @@ EXAMPLES = r"""
     var: remote_status
 - name: Create a ansible remote
   ansible_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_ansible_remote
@@ -77,7 +77,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a ansible remote
   ansible_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_ansible_remote

--- a/plugins/modules/ansible_repository.py
+++ b/plugins/modules/ansible_repository.py
@@ -34,7 +34,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of ansible repositories from pulp api server
   ansible_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: repo_status
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     var: repo_status
 - name: Create a ansible repository
   ansible_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a ansible repository
   ansible_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo

--- a/plugins/modules/ansible_role.py
+++ b/plugins/modules/ansible_role.py
@@ -44,7 +44,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file content units from pulp api server
   ansible_role:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: content_status
@@ -53,7 +53,7 @@ EXAMPLES = r"""
     var: content_status
 - name: Create an ansible role
   ansible_role:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     namespace: geometry

--- a/plugins/modules/ansible_sync.py
+++ b/plugins/modules/ansible_sync.py
@@ -44,7 +44,7 @@ author:
 EXAMPLES = r"""
 - name: Sync ansible remote into repository
   ansible_sync:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: ansible_repo_1

--- a/plugins/modules/artifact.py
+++ b/plugins/modules/artifact.py
@@ -35,7 +35,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of artifacts from pulp server
   artifact:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: artifact_status
@@ -44,21 +44,21 @@ EXAMPLES = r"""
     var: artifact_status
 - name: Upload a file
   artifact:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     file: local_artifact.txt
     state: present
 - name: Delete an artifact by specifying a file
   artifact:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     file: local_artifact.txt
     state: absent
 - name: Delete an artifact by specifying the digest
   artifact:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/plugins/modules/deb_distribution.py
+++ b/plugins/modules/deb_distribution.py
@@ -47,7 +47,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of deb distributions from pulp api server
   deb_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: distribution_status
@@ -57,7 +57,7 @@ EXAMPLES = r"""
 
 - name: Create a deb distribution
   deb_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_deb_distribution
@@ -66,7 +66,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a deb distribution
   deb_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_deb_distribution

--- a/plugins/modules/deb_publication.py
+++ b/plugins/modules/deb_publication.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of deb publications
   deb_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: publication_status
@@ -45,14 +45,14 @@ EXAMPLES = r"""
     var: publication_status
 - name: Create a deb publication
   deb_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_deb_repo
     state: present
 - name: Delete a deb publication
   deb_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_deb_repo

--- a/plugins/modules/deb_remote.py
+++ b/plugins/modules/deb_remote.py
@@ -66,7 +66,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of deb remotes from pulp api server
   deb_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: remote_status
@@ -75,7 +75,7 @@ EXAMPLES = r"""
     var: remote_status
 - name: Create a deb remote
   deb_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_deb_remote
@@ -86,7 +86,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a deb remote
   deb_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_deb_remote

--- a/plugins/modules/deb_repository.py
+++ b/plugins/modules/deb_repository.py
@@ -34,7 +34,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of deb repositories from pulp api server
   deb_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: repo_status
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     var: repo_status
 - name: Create a deb repository
   deb_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a deb repository
   deb_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo

--- a/plugins/modules/deb_sync.py
+++ b/plugins/modules/deb_sync.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Sync deb remote into repository
   deb_sync:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: repo_1

--- a/plugins/modules/delete_orphans.py
+++ b/plugins/modules/delete_orphans.py
@@ -25,7 +25,7 @@ author:
 EXAMPLES = r"""
 - name: Delete orphans
   delete_orphans:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
 """

--- a/plugins/modules/file_content.py
+++ b/plugins/modules/file_content.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file content units from pulp api server
   file_content:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: content_status
@@ -45,7 +45,7 @@ EXAMPLES = r"""
     var: content_status
 - name: Create a file content unit
   file_content:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     sha256: 0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff

--- a/plugins/modules/file_distribution.py
+++ b/plugins/modules/file_distribution.py
@@ -47,7 +47,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file distributions from pulp api server
   file_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: distribution_status
@@ -57,7 +57,7 @@ EXAMPLES = r"""
 
 - name: Create a file distribution
   file_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_distribution
@@ -66,7 +66,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a file distribution
   file_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_distribution

--- a/plugins/modules/file_publication.py
+++ b/plugins/modules/file_publication.py
@@ -41,7 +41,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file publications from pulp api server
   file_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: publication_status
@@ -50,14 +50,14 @@ EXAMPLES = r"""
     var: publication_status
 - name: Create a file publication
   file_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_file_repo
     state: present
 - name: Delete a file publication
   file_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_file_repo

--- a/plugins/modules/file_remote.py
+++ b/plugins/modules/file_remote.py
@@ -54,7 +54,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file remotes from pulp api server
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: remote_status
@@ -63,7 +63,7 @@ EXAMPLES = r"""
     var: remote_status
 - name: Create a file remote
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_remote
@@ -71,7 +71,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a file remote
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_remote

--- a/plugins/modules/file_repository.py
+++ b/plugins/modules/file_repository.py
@@ -34,7 +34,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of file repositories from pulp api server
   file_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: repo_status
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     var: repo_status
 - name: Create a file repository
   file_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a file repository
   file_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo

--- a/plugins/modules/file_repository_content.py
+++ b/plugins/modules/file_repository_content.py
@@ -70,7 +70,7 @@ author:
 EXAMPLES = r"""
 - name: Add or remove content
   file_repository_content:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_repo

--- a/plugins/modules/file_sync.py
+++ b/plugins/modules/file_sync.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Sync file remote into repository
   file_sync:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: file_repo_1

--- a/plugins/modules/python_distribution.py
+++ b/plugins/modules/python_distribution.py
@@ -47,7 +47,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of python distributions
   python_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: distribution_status
@@ -57,7 +57,7 @@ EXAMPLES = r"""
 
 - name: Create a python distribution
   python_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_python_distribution
@@ -67,7 +67,7 @@ EXAMPLES = r"""
 
 - name: Delete a python distribution
   python_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_python_distribution

--- a/plugins/modules/python_publication.py
+++ b/plugins/modules/python_publication.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of python publications
   python_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: publication_status
@@ -45,14 +45,14 @@ EXAMPLES = r"""
     var: publication_status
 - name: Create a python publication
   python_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_python_repo
     state: present
 - name: Delete a python publication
   file_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_python_repo

--- a/plugins/modules/python_remote.py
+++ b/plugins/modules/python_remote.py
@@ -68,7 +68,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of python remotes from pulp api server
   python_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: remote_status
@@ -77,7 +77,7 @@ EXAMPLES = r"""
     var: remote_status
 - name: Create a python remote
   python_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_python_remote
@@ -85,7 +85,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a python remote
   python_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_python_remote

--- a/plugins/modules/python_repository.py
+++ b/plugins/modules/python_repository.py
@@ -34,7 +34,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of python repositories from pulp api server
   python_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: repo_status
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     var: repo_status
 - name: Create a python repository
   python_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a python repository
   python_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo

--- a/plugins/modules/python_sync.py
+++ b/plugins/modules/python_sync.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Sync python remote into repository
   python_sync:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: repo_1

--- a/plugins/modules/rpm_distribution.py
+++ b/plugins/modules/rpm_distribution.py
@@ -47,7 +47,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of rpm distributions
   rpm_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: distribution_status
@@ -57,7 +57,7 @@ EXAMPLES = r"""
 
 - name: Create a rpm distribution
   rpm_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_rpm_distribution
@@ -67,7 +67,7 @@ EXAMPLES = r"""
 
 - name: Delete a rpm distribution
   rpm_distribution:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_rpm_distribution

--- a/plugins/modules/rpm_publication.py
+++ b/plugins/modules/rpm_publication.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of rpm publications
   rpm_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: publication_status
@@ -45,14 +45,14 @@ EXAMPLES = r"""
     var: publication_status
 - name: Create a rpm publication
   rpm_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_rpm_repo
     state: present
 - name: Delete a rpm publication
   rpm_publication:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: my_rpm_repo

--- a/plugins/modules/rpm_remote.py
+++ b/plugins/modules/rpm_remote.py
@@ -54,7 +54,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of rpm remotes from pulp api server
   rpm_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: remote_status
@@ -63,7 +63,7 @@ EXAMPLES = r"""
     var: remote_status
 - name: Create a rpm remote
   rpm_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_rpm_remote
@@ -71,7 +71,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a rpm remote
   rpm_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_rpm_remote

--- a/plugins/modules/rpm_repository.py
+++ b/plugins/modules/rpm_repository.py
@@ -34,7 +34,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of rpm repositories from pulp api server
   rpm_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: repo_status
@@ -43,7 +43,7 @@ EXAMPLES = r"""
     var: repo_status
 - name: Create a rpm repository
   rpm_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo
@@ -51,7 +51,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a rpm repository
   rpm_repository:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_repo

--- a/plugins/modules/rpm_sync.py
+++ b/plugins/modules/rpm_sync.py
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r"""
 - name: Sync rpm remote into repository
   rpm_sync:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     repository: repo_1

--- a/plugins/modules/task.py
+++ b/plugins/modules/task.py
@@ -37,7 +37,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of tasks from pulp server
   tasks:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: task_summary
@@ -47,7 +47,7 @@ EXAMPLES = r"""
 # TODO
 - name: Create a file remote
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_remote
@@ -55,7 +55,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a file remote
   file_remote:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_file_remote

--- a/plugins/modules/x509_cert_guard.py
+++ b/plugins/modules/x509_cert_guard.py
@@ -38,7 +38,7 @@ author:
 EXAMPLES = r"""
 - name: Read list of x509 cert guards from pulp api server
   x509_cert_guard:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
   register: guard_status
@@ -47,7 +47,7 @@ EXAMPLES = r"""
     var: guard_status
 - name: Create a x509 cert guard
   x509_cert_guard:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_cert_guard
@@ -56,7 +56,7 @@ EXAMPLES = r"""
     state: present
 - name: Delete a x509 cert guard
   x509_cert_guard:
-    api_url: localhost:24817
+    pulp_url: https://pulp.example.org
     username: admin
     password: password
     name: new_cert_guard


### PR DESCRIPTION
The EXAMPLES docstring in all modules is out-of-date it seems. I've only started using a few of these modules, and I wasted time with the examples before I realized they were wrong. I expect others will too.

Changed:

- There is no longer an `api_url` parameter. Replaced with `pulp_url`.
- A scheme/protocol (http://) is needed. Added it.

Should I also change the port number?
