### PR TITLE
add Ansible 2.12 and Python 3.9 to CI and simplify matrix definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,38 +14,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["2.7", "3.6", "3.7", "3.8"]
+        python:
+          - "3.8"
         ansible:
           - stable-2.8
           - stable-2.9
           - stable-2.10
           - stable-2.11
+          - stable-2.12
           - devel
-        exclude:
-          - python: "2.7"
-            ansible: "stable-2.8"
-          - python: "2.7"
-            ansible: "stable-2.9"
-          - python: "2.7"
-            ansible: "stable-2.10"
+        include:
           - python: "2.7"
             ansible: "stable-2.11"
           - python: "3.6"
-            ansible: "stable-2.8"
-          - python: "3.6"
-            ansible: "stable-2.9"
-          - python: "3.6"
-            ansible: "stable-2.10"
-          - python: "3.6"
             ansible: "stable-2.11"
           - python: "3.7"
-            ansible: "stable-2.8"
-          - python: "3.7"
-            ansible: "stable-2.9"
-          - python: "3.7"
-            ansible: "stable-2.10"
-          - python: "3.7"
             ansible: "stable-2.11"
+          - python: "3.9"
+            ansible: "devel"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
instead of defining a big matrix and then a ton of excludes, only define
a default matrix for Python 3.8 (the default), and then add jobs for the
other Pythons using include