### PR TITLE
Set orphan protection time to zero

### DIFF
--- a/tests/settings/settings.py
+++ b/tests/settings/settings.py
@@ -1,2 +1,3 @@
 CONTENT_ORIGIN = "http://localhost:8080/"
 ALLOWED_EXPORT_PATHS = ["/tmp"]
+ORPHAN_PROTECTION_TIME = 0


### PR DESCRIPTION
This allows to clean artifacts between tests.