### PR TITLE
run_container.sh: Remove pulp container on exit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
           http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
           docker images || true
           docker ps -a || true
-          docker logs pulp || true
+          cat tests/pulp.log || true
 
   sanity:
     runs-on: ubuntu-latest

--- a/tests/run_container.sh
+++ b/tests/run_container.sh
@@ -41,8 +41,13 @@ fi
 # show pulpcore/plugin versions we're using
 curl -s http://localhost:8080/pulp/api/v3/status/ | jq ".versions"
 
+exit_handler() {
+    "${CONTAINER_RUNTIME}" logs pulp > ${BASEPATH}/pulp.log 2>&1
+    "${CONTAINER_RUNTIME}" rm -f pulp
+}
+
 # shellcheck disable=SC2064
-trap "${CONTAINER_RUNTIME} stop pulp" EXIT
+trap exit_handler EXIT
 
 # Set admin password
 "${CONTAINER_RUNTIME}" exec pulp pulpcore-manager reset-admin-password --password password


### PR DESCRIPTION
Removing the container means we can run the script multiple times.

Related: #76 