### PR TITLE
Restructure log capturing in live tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,6 @@ jobs:
       - name: Run live tests
         run: IMAGE_TAG=nightly tests/run_container.sh make livetest
         if: (matrix.ansible == 'devel') && (matrix.python == '3.8')
-      - name: After failure
-        if: failure() && (matrix.ansible == 'devel') && (matrix.python == '3.8')
-        run: |
-          http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
-          docker images || true
-          docker ps -a || true
-          docker logs pulp || true
 
   sanity:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 *.pyo
 *.tar.gz
 /tests/playbooks/vars/server.yaml
+/tests/settings/certs/
 /build/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+import subprocess
 
 
 def pytest_addoption(parser):
@@ -14,3 +16,35 @@ def pytest_addoption(parser):
 @pytest.fixture
 def vcrmode(request):
     return request.config.getoption("vcrmode")
+
+
+if "PULP_LOGGING" in os.environ:
+
+    @pytest.fixture
+    def pulp_container_log(vcrmode):
+        if vcrmode == "live":
+            with subprocess.Popen(
+                [
+                    os.environ["PULP_LOGGING"],
+                    "logs",
+                    "-f",
+                    "--tail",
+                    "0",
+                    "pulp-ephemeral",
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            ) as proc:
+                yield
+                proc.kill()
+                print(proc.stdout.read().decode())
+        else:
+            yield
+
+
+else:
+
+    @pytest.fixture
+    def pulp_container_log():
+        yield

--- a/tests/run_container.sh
+++ b/tests/run_container.sh
@@ -4,7 +4,7 @@ set -eu
 
 BASEPATH="$(dirname "$(readlink -f "$0")")"
 
-if [ -z "${CONTAINER_RUNTIME+x}" ]
+if [ -z "${CONTAINER_RUNTIME:+x}" ]
 then
   if ls /usr/bin/podman
   then
@@ -14,12 +14,19 @@ then
   fi
 fi
 
-if [ -z "${IMAGE_TAG+x}" ]
+if [ -z "${KEEP_CONTAINER:+x}" ]
 then
-  IMAGE_TAG="latest"
+  RM="yes"
+else
+  RM=""
 fi
 
-"${CONTAINER_RUNTIME}" run --detach --name "pulp" --volume "${BASEPATH}/settings:/etc/pulp" --publish "8080:80" "pulp/pulp:$IMAGE_TAG"
+"${CONTAINER_RUNTIME}" run ${RM:+--rm} --detach --name "pulp-ephemeral" --volume "${BASEPATH}/settings:/etc/pulp" --publish "8080:80" "pulp/pulp:${IMAGE_TAG:-latest}"
+
+# shellcheck disable=SC2064
+trap "${CONTAINER_RUNTIME} stop pulp-ephemeral" EXIT
+# shellcheck disable=SC2064
+trap "${CONTAINER_RUNTIME} stop pulp-ephemeral" INT
 
 echo "Wait for pulp to start."
 for counter in $(seq 20)
@@ -35,16 +42,16 @@ done
 if [ "$counter" = "0" ]
 then
   echo "FAIL."
+  "${CONTAINER_RUNTIME}" images
+  "${CONTAINER_RUNTIME}" ps -a
+  "${CONTAINER_RUNTIME}" logs "pulp-ephemeral"
   exit 1
 fi
 
 # show pulpcore/plugin versions we're using
-curl -s http://localhost:8080/pulp/api/v3/status/ | jq ".versions"
-
-# shellcheck disable=SC2064
-trap "${CONTAINER_RUNTIME} stop pulp" EXIT
+curl -s http://localhost:8080/pulp/api/v3/status/ | jq '.versions|map({key: .component, value: .version})|from_entries'
 
 # Set admin password
-"${CONTAINER_RUNTIME}" exec pulp pulpcore-manager reset-admin-password --password password
+"${CONTAINER_RUNTIME}" exec "pulp-ephemeral" pulpcore-manager reset-admin-password --password password
 
 PULP_LOGGING="${CONTAINER_RUNTIME}" "$@"

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -73,7 +73,7 @@ def run_playbook(test_name, extra_vars=None, limit=None, check_mode=False):
 
 
 @pytest.mark.parametrize("test_name", TEST_NAMES)
-def test_playbook(tmpdir, test_name, vcrmode):
+def test_playbook(tmpdir, test_name, vcrmode, pulp_container_log):
     if vcrmode == "live":
         run = run_playbook(test_name)
     else:
@@ -93,7 +93,8 @@ def test_playbook(tmpdir, test_name, vcrmode):
 
 
 @pytest.mark.parametrize("test_name", TEST_NAMES)
-def test_check_mode(tmpdir, test_name):
+def test_check_mode(tmpdir, test_name, vcrmode):
+    assert vcrmode == "replay", "Check-mode tests only work in replay."
     # if test_name == 'not_working_one':
     #     pytest.skip("TODO: Fix check_mode test for not_working_one.")
     run = run_playbook_vcr(tmpdir, test_name, check_mode=True)


### PR DESCRIPTION
This will capture server logs from the container in livetests test by
test, and remove the ephemeral test container in run_container.sh by
default. Also capturing the container logs is moved from an after
failure stage into run_container.sh.