### PR TITLE
Fix idempotency for publications

### DIFF
--- a/plugins/module_utils/pulp.py
+++ b/plugins/module_utils/pulp.py
@@ -163,6 +163,16 @@ class PulpEntity(object):
         search_result = self.module.pulp_api.call(self._list_id, parameters=parameters)
         if search_result["count"] == 1:
             self.entity = search_result["results"][0]
+        elif search_result["count"] > 1:
+            # While we limit to one result, the count may be more than one.
+            # This may happen for models with an insufficient or non-existent "natural key"
+            # e.g. for a publication.
+            raise SqueezerException(
+                "Found multiple matches for {entity_type} ({entity_key}).".format(
+                    entity_type=self._name_singular,
+                    entity_key=self.natural_key,
+                )
+            )
         elif failsafe:
             self.entity = None
         else:


### PR DESCRIPTION
If there are multiple publications of a repository version, then the
rpm_publication module will create another, rather than keeping or
updating one of the existing ones.

This happens due to the find() method on PulpEntity looking for
count==1. It uses a limit of one, so only one result is returned, but
the count still gives the full number of matching items, which in this
case is 2.

 This change fixes the issue by failing when we cannot find a unique
 entity matching the requested parameters.

Fixes: #84