### PR TITLE
Adjust for pulpcore rename in access_policy

### DIFF
--- a/plugins/module_utils/pulp.py
+++ b/plugins/module_utils/pulp.py
@@ -29,6 +29,21 @@ class SqueezerException(Exception):
     pass
 
 
+def pulp_parse_version(version_str):
+    """Return a version string as a list of ints or strings."""
+    # Examples:
+    # "1.2.3" -> [1, 2, 3]
+    # "1.2.3-dev" -> [1, 2, 3, "dev"]
+
+    def try_convert_int(i):
+        try:
+            return int(i)
+        except ValueError:
+            return i
+
+    return [try_convert_int(i) for i in re.split(r"[\.\-]", version_str)]
+
+
 class PulpAnsibleModule(AnsibleModule):
     def __init__(self, **kwargs):
         argument_spec = dict(

--- a/plugins/modules/rpm_sync.py
+++ b/plugins/modules/rpm_sync.py
@@ -64,29 +64,13 @@ RETURN = r"""
 """
 
 
-import re
-
 from ansible_collections.pulp.squeezer.plugins.module_utils.pulp import (
+    pulp_parse_version,
     PulpAnsibleModule,
     PulpRpmRemote,
     PulpRpmRepository,
     SqueezerException,
 )
-
-
-def _parse_version(version_str):
-    """Return a version string as a list of ints or strings."""
-    # Examples:
-    # "1.2.3" -> [1, 2, 3]
-    # "1.2.3-dev" -> [1, 2, 3, "dev"]
-
-    def try_convert_int(i):
-        try:
-            return int(i)
-        except ValueError:
-            return i
-
-    return [try_convert_int(i) for i in re.split(r"[\.\-]", version_str)]
 
 
 def main():
@@ -115,7 +99,7 @@ def main():
             .get("x-pulp-app-versions", {})
             .get("rpm", ())
         )
-        if _parse_version(rpm_version) >= _parse_version("3.16.0"):
+        if pulp_parse_version(rpm_version) >= pulp_parse_version("3.16.0"):
             parameters = {"sync_policy": module.params["sync_policy"]}
         elif module.params["sync_policy"] == "mirror_content_only":
             raise SqueezerException(

--- a/tests/playbooks/access_policy.yaml
+++ b/tests/playbooks/access_policy.yaml
@@ -92,6 +92,6 @@
       pulp.squeezer.access_policy:
         viewset_name: tasks
         statements: "{{ saved_access_policy.access_policy.statements }}"
-        permissions_assignment: "{{ saved_access_policy.access_policy.permissions_assignment }}"
+        creation_hooks: "{{ saved_access_policy.access_policy.creation_hooks | default(saved_access_policy.access_policy.permissions_assignment | default(omit)) }}"
         state: present
 ...


### PR DESCRIPTION
Starting with pulpcore 3.17.0 permissions_assignment is renamed to
creation_hooks.