### PR TITLE
bump version to 0.0.13

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,8 @@ authors:
   - "keilr <remy.keil@gmail.com>"
   - "Mark Goddard <mark@stackhpc.com>"
   - "Daniel Ziegenberg <daniel@ziegenberg.at>"
-version: "0.0.13-dev"
+  - "Alex Welsh <alex@stackhpc.com>"
+version: "0.0.13"
 license_file: LICENSE
 readme: README.md
 repository: "https://github.com/pulp/squeezer"


### PR DESCRIPTION
Matthias, my CI needs an up to date version on ansible galaxy to be able to properly pull and run with the new upgrades. I'd appreciate it if you could bump the version.