### PR TITLE
Add username and password to status.yaml

### DIFF
--- a/tests/playbooks/status.yaml
+++ b/tests/playbooks/status.yaml
@@ -5,6 +5,8 @@
     - vars/server.yaml
   module_defaults: &pulp_module_defaults
     pulp.squeezer.status: &pulp_connection_details
+      username: "{{ pulp_username }}"
+      password: "{{ pulp_password }}"
       pulp_url: "{{ pulp_url }}"
       validate_certs: "{{ pulp_validate_certs | default(true) }}"
   tasks:


### PR DESCRIPTION
If username and password is not provided, the following error message is shown

``` 
["missing required arguments: username, password"](fatal: [somehost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "msg": "missing required arguments: username, password"})
```

For that reason, password and username were added with the values defined in vars/server.yaml.