### PR TITLE
add support for ansible action_groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ SANITY_OPTS =
 TEST =
 PYTEST = pytest -n 4 -v
 
+ACTION_GROUPS := $(shell python -c 'import yaml; print("".join(yaml.safe_load(open("meta/runtime.yml"))["action_groups"]["squeezer"]))')
+MODULES := $(shell python -c 'import os; print("".join([os.path.splitext(f)[0] for f in sorted(os.listdir("plugins/modules/"))]))')
+
 default: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -45,6 +48,9 @@ lint: $(MANIFEST) | tests/playbooks/vars/server.yaml
 	ansible-playbook --syntax-check tests/playbooks/*.yaml | grep -v '^$$'
 	black --check --diff .
 	isort -c --diff .
+ifneq ($(ACTION_GROUPS), $(MODULES))
+	@echo 'plugins/modules/ and meta/runtime.yml action_groups are not in sync' && exit 1
+endif
 	GALAXY_IMPORTER_CONFIG=tests/galaxy-importer.cfg python -m galaxy_importer.main $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz
 	@echo "🙊 Code 🙉 LGTM 🙈"
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,44 @@
 ---
 requires_ansible: ">=2.8"
+action_groups:
+  squeezer:
+    - access_policy
+    - ansible_distribution
+    - ansible_remote
+    - ansible_repository
+    - ansible_role
+    - ansible_sync
+    - api_call
+    - artifact
+    - container_distribution
+    - container_remote
+    - container_repository
+    - container_sync
+    - deb_distribution
+    - deb_publication
+    - deb_remote
+    - deb_repository
+    - deb_sync
+    - delete_orphans
+    - file_content
+    - file_distribution
+    - file_publication
+    - file_remote
+    - file_repository
+    - file_repository_content
+    - file_sync
+    - purge_tasks
+    - python_distribution
+    - python_publication
+    - python_remote
+    - python_repository
+    - python_sync
+    - rpm_distribution
+    - rpm_publication
+    - rpm_remote
+    - rpm_repository
+    - rpm_sync
+    - status
+    - task
+    - x509_cert_guard
 ...


### PR DESCRIPTION
see https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#meta-directory-and-runtime-yml

The list was generated with:

```shell
find plugins/modules/ -type f | xargs -n1 basename -s .py | sort | awk '$0="    - "$0'
```