### PR TITLE
ISSUE-154 - Add retain_package_versions to rpm_repository.py and associated tests

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,6 +16,7 @@ authors:
   - "Christian Loos <cloos@netsandbox.de>"
   - "Kevin P. Fleming <kevin@km6g.us>"
   - "Alessandro Taufer <alexander141220@gmail.com>"
+  - "Chris Taylor <taylorcw@gmail.com>"
 version: "0.0.16-dev"
 license_file: LICENSE
 readme: README.md

--- a/plugins/modules/rpm_repository.py
+++ b/plugins/modules/rpm_repository.py
@@ -41,6 +41,11 @@ options:
       - A JSON document or data structure describing a config.repo file
     type: raw
     version_added: "0.0.16"
+  retain_package_versions:
+    description:
+      - Max number of latest versions of each package to keep (optional)
+    type: int
+    version_added: "0.0.16"
 extends_documentation_fragment:
   - pulp.squeezer.pulp
   - pulp.squeezer.pulp.entity_state
@@ -69,6 +74,7 @@ EXAMPLES = r"""
     description: A brand new repository with a description
     autopublish: true
     remote: existing_remote
+    retain_package_versions: 3
     repo_config:
       gpgcheck: 1
     state: present
@@ -102,7 +108,7 @@ from ansible_collections.pulp.squeezer.plugins.module_utils.pulp import (
     PulpRpmRepository,
 )
 
-DESIRED_KEYS = {"autopublish", "remote", "repo_config"}
+DESIRED_KEYS = {"autopublish", "remote", "repo_config", "retain_package_versions"}
 
 
 def main():
@@ -113,6 +119,7 @@ def main():
             autopublish=dict(type="bool"),
             remote=dict(),
             repo_config=dict(type="raw"),
+            retain_package_versions=dict(type="int"),
         ),
         required_if=[("state", "present", ["name"]), ("state", "absent", ["name"])],
     ) as module:

--- a/tests/fixtures/rpm_repository-1.yml
+++ b/tests/fixtures/rpm_repository-1.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/remotes/rpm/rpm/?limit=1&name=test_rpm_remote
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","pulp_created":"2024-03-05T17:15:32.406058Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"pulp_labels":{},"pulp_last_updated":"2024-03-05T17:15:32.406069Z","download_concurrency":null,"max_retries":null,"policy":"immediate","total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"rate_limit":null,"hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"sles_auth_token":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","pulp_created":"2024-04-04T20:23:41.016518Z","pulp_last_updated":"2024-04-04T20:23:41.016539Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"pulp_labels":{},"download_concurrency":null,"max_retries":null,"policy":"immediate","total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"rate_limit":null,"hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"sles_auth_token":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +29,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - ece08571f0dc4a739f8097272f639a93
+      - 8cd179487da8444da39fb0f94ada5bae
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:36 GMT
+      - Thu, 04 Apr 2024 20:23:50 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -59,7 +59,7 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
@@ -77,11 +77,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7e690ff098a047e3b82d778f23d7aab6
+      - 09755bf03dd84afaaaa3f81cad8f50f4
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:36 GMT
+      - Thu, 04 Apr 2024 20:23:50 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -96,7 +96,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"name": "test_rpm_repository", "remote": "/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/",
+    body: '{"name": "test_rpm_repository", "remote": "/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/",
       "description": null}'
     headers:
       Accept:
@@ -110,12 +110,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: POST
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:51.474134Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -124,17 +124,17 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '771'
+      - '821'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 98202fb1d35d473cb55fb6eea7ab9052
+      - b19c1b1c93a349c9ac77b248e61f73d9
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:37 GMT
+      - Thu, 04 Apr 2024 20:23:51 GMT
       Location:
-      - /pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+      - /pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-10.yml
+++ b/tests/fixtures/rpm_repository-10.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:08.746242Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         0}","compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -27,15 +27,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '917'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 51acbc4374c94855991ed582eb4f258f
+      - c41b59833af644a1b78d24cb44a33892
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:43 GMT
+      - Thu, 04 Apr 2024 20:24:11 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-11.yml
+++ b/tests/fixtures/rpm_repository-11.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:08.746242Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         0}","compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -27,15 +27,162 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '917'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 21436fbf61954dbba56c775b5d3bb30c
+      - 31c4fa14d14841a48b4e85133b6dcd83
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:43 GMT
+      - Thu, 04 Apr 2024 20:24:12 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"retain_package_versions": 3}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Length:
+      - 30
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-8b14-7e8e-8399-8084f1c0eadd/"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 0765cd10ff894411b4ab99425cb39759
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:13 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-8b14-7e8e-8399-8084f1c0eadd/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-8b14-7e8e-8399-8084f1c0eadd/","pulp_created":"2024-04-04T20:24:13.332831Z","pulp_last_updated":"2024-04-04T20:24:13.332855Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"0765cd10ff894411b4ab99425cb39759","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:13.345311Z","started_at":"2024-04-04T20:24:13.346377Z","finished_at":"2024-04-04T20:24:13.357511Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '874'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - aea7eec718664a6fae7b3c9c4181521c
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:14 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:13.354317Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '848'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 4a22f33ddebd4909b79b7d0d7ba3e423
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:14 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-12.yml
+++ b/tests/fixtures/rpm_repository-12.yml
@@ -11,14 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=20&offset=0
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
-        0}","compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:13.354317Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -27,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - fc443bb57a9b4944a1f04a0396abb918
+      - 5f0374445aa44bce964579a8adca9d37
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:44 GMT
+      - Thu, 04 Apr 2024 20:24:16 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-13.yml
+++ b/tests/fixtures/rpm_repository-13.yml
@@ -11,14 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
-        0}","compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:13.354317Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -27,15 +26,162 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - e5702ca805e746a9bd3d9b212c52e577
+      - 1d41083cdf644b80990b093ef39c6acf
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:44 GMT
+      - Thu, 04 Apr 2024 20:24:17 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"retain_package_versions": 0}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Length:
+      - 30
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-9d0c-7485-a347-112fef92e98e/"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - f07e1cb38a7e47d7afe82f3640b68830
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:17 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-9d0c-7485-a347-112fef92e98e/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-9d0c-7485-a347-112fef92e98e/","pulp_created":"2024-04-04T20:24:17.932754Z","pulp_last_updated":"2024-04-04T20:24:17.932781Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"f07e1cb38a7e47d7afe82f3640b68830","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:17.944384Z","started_at":"2024-04-04T20:24:17.945611Z","finished_at":"2024-04-04T20:24:17.954510Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '874'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 5e0f3a95ad6649e3b1c0da3b7a885340
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:18 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '848'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - a5570b9b59584d3ab9608c4e9c59fdb7
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:19 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-14.yml
+++ b/tests/fixtures/rpm_repository-14.yml
@@ -11,14 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
-        0}","compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -27,161 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 8a29e98710a3426b85a130f79a2bc1f8
+      - a51e0da4207b4c2ab7db87ff2ddf489e
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:44 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"description": null}'
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Length:
-      - 21
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
-  response:
-    body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-3671-7644-96b5-aeb3c8edf5bf/"}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 0068d38464d949a1b5614ca3884149d8
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:45 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-3671-7644-96b5-aeb3c8edf5bf/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-3671-7644-96b5-aeb3c8edf5bf/","pulp_created":"2024-03-05T17:15:45.138573Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"0068d38464d949a1b5614ca3884149d8","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:45.154202Z","finished_at":"2024-03-05T17:15:45.171552Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '656'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - f480fb8e2b9e47a4a431e365b7668277
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:45 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '770'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 44352d799f774530b4bc36cdc52085b7
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:45 GMT
+      - Thu, 04 Apr 2024 20:24:20 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-15.yml
+++ b/tests/fixtures/rpm_repository-15.yml
@@ -11,12 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '822'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - f254e68d62784053a5db1def3d8a7363
+      - 835ef55f347e4c1b8496a4dd67b945fa
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:45 GMT
+      - Thu, 04 Apr 2024 20:24:21 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-16.yml
+++ b/tests/fixtures/rpm_repository-16.yml
@@ -11,12 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=20&offset=0
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,161 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '822'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 931b55f4e85c452199306fef52acf98e
+      - 88be785cefa14be88ae902a4de7a91c9
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:46 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"autopublish": false}'
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Length:
-      - 22
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
-  response:
-    body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-3c2f-7553-83c0-7e290da21481/"}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 29eeaad3fd3b456c85381d8e32fda68f
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:46 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-3c2f-7553-83c0-7e290da21481/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-3c2f-7553-83c0-7e290da21481/","pulp_created":"2024-03-05T17:15:46.608241Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"29eeaad3fd3b456c85381d8e32fda68f","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:46.622491Z","finished_at":"2024-03-05T17:15:46.642299Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '656'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - d986cb2e79d14a6c9a8378effa2bc7c5
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:46 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.10
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '771'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - a501c3d7b8ec4678ab92ed7093448059
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Tue, 05 Mar 2024 17:15:47 GMT
+      - Thu, 04 Apr 2024 20:24:23 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-17.yml
+++ b/tests/fixtures/rpm_repository-17.yml
@@ -11,12 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '823'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 8eb81e9c2b8b4aecb3e8d85a8ca2b904
+      - ccf9bb73e6624b1d9d7ddae02032c79c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:47 GMT
+      - Thu, 04 Apr 2024 20:24:24 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-18.yml
+++ b/tests/fixtures/rpm_repository-18.yml
@@ -11,12 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:17.951897Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '823'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - aa11ab28106841d596670b60f78c2f09
+      - ab2a1142b3a840a1a0fafa0ad1482d6a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:47 GMT
+      - Thu, 04 Apr 2024 20:24:26 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -48,23 +49,25 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"description": null}'
     headers:
       Accept:
       - application/json
       Connection:
       - close
+      Content-Length:
+      - 21
       Content-Type:
       - application/json
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
-    method: DELETE
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+      - Python-urllib/3.9
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-4240-7bfd-98ac-8c37d3fb2012/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-bf2b-7136-abcb-27493f5dbc6b/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -77,11 +80,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 49208e22fb6e48d9b093c221fe1ca848
+      - 5994e3a26f2949baa49501c9f5b7739c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:48 GMT
+      - Thu, 04 Apr 2024 20:24:26 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -107,12 +110,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-4240-7bfd-98ac-8c37d3fb2012/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-bf2b-7136-abcb-27493f5dbc6b/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-4240-7bfd-98ac-8c37d3fb2012/","pulp_created":"2024-03-05T17:15:48.161459Z","state":"completed","name":"pulpcore.app.tasks.base.general_delete","logging_cid":"49208e22fb6e48d9b093c221fe1ca848","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:48.214696Z","finished_at":"2024-03-05T17:15:48.242815Z","error":null,"worker":"/pulp/api/v3/workers/018e0f9c-e237-78bb-bafb-1ac5f17456a0/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-bf2b-7136-abcb-27493f5dbc6b/","pulp_created":"2024-04-04T20:24:26.667720Z","pulp_last_updated":"2024-04-04T20:24:26.667743Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"5994e3a26f2949baa49501c9f5b7739c","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:26.682331Z","started_at":"2024-04-04T20:24:26.683553Z","finished_at":"2024-04-04T20:24:26.697270Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -121,15 +124,63 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '712'
+      - '874'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 6d79097060f0411b948abc48dda98e53
+      - eec9e3fdad6044d8abf243e66dd099aa
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:48 GMT
+      - Thu, 04 Apr 2024 20:24:27 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:26.693366Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '820'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 1e6cc667e051457a85f5ddeb59d22eb0
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:27 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-19.yml
+++ b/tests/fixtures/rpm_repository-19.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:26.693366Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +25,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '52'
+      - '872'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 523db19b73ac4ab68d6f8af0207946b8
+      - ec9e4f01f70e490d9ebe1b842e5a1d69
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:48 GMT
+      - Thu, 04 Apr 2024 20:24:29 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-2.yml
+++ b/tests/fixtures/rpm_repository-2.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:51.474134Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +25,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '823'
+      - '873'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 8d3ead25270f49c7a2882da17435ee4b
+      - 911d7e7866be4f43a396fdf03844643d
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:37 GMT
+      - Thu, 04 Apr 2024 20:23:52 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-20.yml
+++ b/tests/fixtures/rpm_repository-20.yml
@@ -1,0 +1,196 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:26.693366Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 6e384a1f612b4a3a9d5b3bcbd3b456fa
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:30 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"autopublish": false}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Length:
+      - 22
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-d1a2-7332-b047-5ae86f04d2e2/"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - e48c47b0c050493b9bcfbd9b7844163e
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:31 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-d1a2-7332-b047-5ae86f04d2e2/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-d1a2-7332-b047-5ae86f04d2e2/","pulp_created":"2024-04-04T20:24:31.395529Z","pulp_last_updated":"2024-04-04T20:24:31.395551Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"e48c47b0c050493b9bcfbd9b7844163e","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:31.408054Z","started_at":"2024-04-04T20:24:31.409097Z","finished_at":"2024-04-04T20:24:31.418100Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '874'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 7a06abfde180473f88c3ff4627db2edc
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:32 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:31.415286Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '821'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 415073a0e43d45a493120bbe23595050
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:32 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/rpm_repository-21.yml
+++ b/tests/fixtures/rpm_repository-21.yml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:31.415286Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - e76c0441423f49ebb52821ecb4a5969c
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:34 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/rpm_repository-22.yml
+++ b/tests/fixtures/rpm_repository-22.yml
@@ -1,0 +1,146 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:31.415286Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 068be1ebf31949a091d8136e381a7134
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:35 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: DELETE
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
+  response:
+    body:
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-e3ae-7b9d-a635-911cafe25fb0/"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - a9fe239a77bd42cb9d9f03053377b4f6
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:36 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-e3ae-7b9d-a635-911cafe25fb0/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-e3ae-7b9d-a635-911cafe25fb0/","pulp_created":"2024-04-04T20:24:36.015364Z","pulp_last_updated":"2024-04-04T20:24:36.015395Z","state":"completed","name":"pulpcore.app.tasks.base.general_delete","logging_cid":"a9fe239a77bd42cb9d9f03053377b4f6","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:36.076284Z","started_at":"2024-04-04T20:24:36.140786Z","finished_at":"2024-04-04T20:24:36.210820Z","error":null,"worker":"/pulp/api/v3/workers/018eaac7-c36f-7376-a216-45ee1848358d/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '930'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - af91b624f73c452281e4a603229826e7
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:36 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/rpm_repository-23.yml
+++ b/tests/fixtures/rpm_repository-23.yml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      User-Agent:
+      - Python-urllib/3.9
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Connection:
+      - close
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - af7b0245cbe1405cb3eab502556568b2
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Thu, 04 Apr 2024 20:24:38 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/rpm_repository-3.yml
+++ b/tests/fixtures/rpm_repository-3.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:51.474134Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,15 +25,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '823'
+      - '873'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 2ba831f4adcd4382bde6de516c51a09c
+      - b2f6013627ce477dbeb15a942545e0fd
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:37 GMT
+      - Thu, 04 Apr 2024 20:23:54 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -61,12 +61,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-1ae4-7ef1-aee0-67ec166209e8/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-4210-7dcd-af5f-a3d0581c95c8/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -79,11 +79,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 6cbea4ecd6ef467091e4bff9d08f920c
+      - 8b34fc6b6ae24327ad5ab014cbfcc627
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:38 GMT
+      - Thu, 04 Apr 2024 20:23:54 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -109,12 +109,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-1ae4-7ef1-aee0-67ec166209e8/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-4210-7dcd-af5f-a3d0581c95c8/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-1ae4-7ef1-aee0-67ec166209e8/","pulp_created":"2024-03-05T17:15:38.085053Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"6cbea4ecd6ef467091e4bff9d08f920c","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:38.105247Z","finished_at":"2024-03-05T17:15:38.110402Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-4210-7dcd-af5f-a3d0581c95c8/","pulp_created":"2024-04-04T20:23:54.641507Z","pulp_last_updated":"2024-04-04T20:23:54.641538Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"8b34fc6b6ae24327ad5ab014cbfcc627","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:23:54.663186Z","started_at":"2024-04-04T20:23:54.664127Z","finished_at":"2024-04-04T20:23:54.673388Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -123,15 +123,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '656'
+      - '874'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 82a62ffc733b4da686f4ffb774e8b793
+      - b74998bf576f439a974c8c59b0d50785
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:38 GMT
+      - Thu, 04 Apr 2024 20:23:55 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -157,13 +157,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:54.670561Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -172,15 +172,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '799'
+      - '849'
       Content-Type:
       - application/json
       Correlation-ID:
-      - a8442fa719454481aed0f11e5e23dfd2
+      - 21f5df26cc484a298ec7ce95ba79baa1
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:38 GMT
+      - Thu, 04 Apr 2024 20:23:56 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-4.yml
+++ b/tests/fixtures/rpm_repository-4.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:54.670561Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -26,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '851'
+      - '901'
       Content-Type:
       - application/json
       Correlation-ID:
-      - f72297a3a2c44c438f1f3e294c95b35b
+      - e5fbd3989ea54a5ab28cb07ef070c926
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:38 GMT
+      - Thu, 04 Apr 2024 20:23:57 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-5.yml
+++ b/tests/fixtures/rpm_repository-5.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:54.670561Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -26,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '851'
+      - '901'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 1c73c687eefe4396a0eb473e552a5bab
+      - 465c83ac25f841bb8cfa9fc0d7ef36cc
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:39 GMT
+      - Thu, 04 Apr 2024 20:23:58 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -62,12 +62,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-2069-717f-8168-5b6a9325f6e9/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-540b-7af8-aea4-72dea74c2a31/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -80,11 +80,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 59049978cb9d477d9dcc0bbd470938a0
+      - b63027fc7ad8410a82c12c4c6cc1940d
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:39 GMT
+      - Thu, 04 Apr 2024 20:23:59 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -110,12 +110,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-2069-717f-8168-5b6a9325f6e9/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-540b-7af8-aea4-72dea74c2a31/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-2069-717f-8168-5b6a9325f6e9/","pulp_created":"2024-03-05T17:15:39.498105Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"59049978cb9d477d9dcc0bbd470938a0","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:39.511227Z","finished_at":"2024-03-05T17:15:39.516275Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-540b-7af8-aea4-72dea74c2a31/","pulp_created":"2024-04-04T20:23:59.243889Z","pulp_last_updated":"2024-04-04T20:23:59.243911Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"b63027fc7ad8410a82c12c4c6cc1940d","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:23:59.255733Z","started_at":"2024-04-04T20:23:59.256702Z","finished_at":"2024-04-04T20:23:59.266503Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -124,15 +124,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '656'
+      - '874'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 820f027d0a274b88802a83a2ff996249
+      - 63b3fd9fcd214e59b5dca76e147e45df
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:39 GMT
+      - Thu, 04 Apr 2024 20:23:59 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -158,13 +158,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:59.263086Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -173,15 +173,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '798'
+      - '848'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 92b349f61c2e49f1b3fe49e2c9a7832d
+      - 4c50537b7be4453ebf9b09a084912ec8
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:39 GMT
+      - Thu, 04 Apr 2024 20:24:00 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-6.yml
+++ b/tests/fixtures/rpm_repository-6.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:59.263086Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -26,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '850'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - e4179aa91ff046aa9fead17693c5f5d4
+      - 5d03a575218e40ba92855ee33f200f86
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:40 GMT
+      - Thu, 04 Apr 2024 20:24:02 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-7.yml
+++ b/tests/fixtures/rpm_repository-7.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:23:59.263086Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -26,15 +26,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '850'
+      - '900'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 74cedd060e964f639fa073e076a211e8
+      - 7dab2fd97f8249c8817951d4c788866a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:40 GMT
+      - Thu, 04 Apr 2024 20:24:03 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -62,12 +62,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-25e9-7068-9c4e-77e0ee08333e/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-66d2-7738-92a9-4a2ffa68450c/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -80,11 +80,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 20da8171211a46268cd749bec8375b16
+      - ebd8c054d7ca462e956683cfea27d5b5
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:40 GMT
+      - Thu, 04 Apr 2024 20:24:04 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -110,12 +110,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-25e9-7068-9c4e-77e0ee08333e/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-66d2-7738-92a9-4a2ffa68450c/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-25e9-7068-9c4e-77e0ee08333e/","pulp_created":"2024-03-05T17:15:40.905793Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"20da8171211a46268cd749bec8375b16","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:40.919938Z","finished_at":"2024-03-05T17:15:40.939741Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-66d2-7738-92a9-4a2ffa68450c/","pulp_created":"2024-04-04T20:24:04.051356Z","pulp_last_updated":"2024-04-04T20:24:04.051386Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"ebd8c054d7ca462e956683cfea27d5b5","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:04.068072Z","started_at":"2024-04-04T20:24:04.069461Z","finished_at":"2024-04-04T20:24:04.083100Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -124,15 +124,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '656'
+      - '874'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 74df40f8ef1d48e697622b6a07d10038
+      - 77173a57867740a9994db07e97475556
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:41 GMT
+      - Thu, 04 Apr 2024 20:24:04 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -158,13 +158,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:04.078709Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         1}","compression_type":null}'
     headers:
       Access-Control-Expose-Headers:
@@ -174,15 +174,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '815'
+      - '865'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 10ff70181b3d40bbbe3392ab1a214a1d
+      - 521d9a548bee44ce82d47ddf9f7f8dde
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:41 GMT
+      - Thu, 04 Apr 2024 20:24:05 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-8.yml
+++ b/tests/fixtures/rpm_repository-8.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:04.078709Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         1}","compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -27,15 +27,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '917'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 31fbdf14a43d4e4993fb91a6aa7fb340
+      - 8dd2f204e922450b89f23d4347a3f7aa
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:41 GMT
+      - Thu, 04 Apr 2024 20:24:06 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-9.yml
+++ b/tests/fixtures/rpm_repository-9.yml
@@ -11,13 +11,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:04.078709Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         1}","compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -27,15 +27,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '867'
+      - '917'
       Content-Type:
       - application/json
       Correlation-ID:
-      - db29e67f96c44ceb913a6cd62eac425c
+      - 62c2d34923e944e1a6d61728ee291f86
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:42 GMT
+      - Thu, 04 Apr 2024 20:24:08 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -63,12 +63,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/018e0f9d-2b7c-732f-b314-3e946b6bb2cc/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018eaac8-7916-7f8e-9f17-4effb6da771b/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -81,11 +81,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 9d30b5e609a94d3785b7901e69ce82cc
+      - 9d7700d5906a432db2c2aa8f8f828444
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:42 GMT
+      - Thu, 04 Apr 2024 20:24:08 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -111,12 +111,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/018e0f9d-2b7c-732f-b314-3e946b6bb2cc/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018eaac8-7916-7f8e-9f17-4effb6da771b/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/018e0f9d-2b7c-732f-b314-3e946b6bb2cc/","pulp_created":"2024-03-05T17:15:42.333189Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"9d30b5e609a94d3785b7901e69ce82cc","created_by":"/pulp/api/v3/users/1/","started_at":"2024-03-05T17:15:42.347264Z","finished_at":"2024-03-05T17:15:42.366380Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","shared:/pulp/api/v3/domains/018e0f9c-3b13-7ad6-b01d-d773ce6de325/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018eaac8-7916-7f8e-9f17-4effb6da771b/","pulp_created":"2024-04-04T20:24:08.726808Z","pulp_last_updated":"2024-04-04T20:24:08.726833Z","state":"completed","name":"pulpcore.app.tasks.base.general_update","logging_cid":"9d7700d5906a432db2c2aa8f8f828444","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-04T20:24:08.739352Z","started_at":"2024-04-04T20:24:08.740315Z","finished_at":"2024-04-04T20:24:08.749094Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["prn:rpm.rpmrepository:018eaac8-35a5-7499-89ea-29e8cd1913c7","/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","shared:prn:core.domain:018eaac6-4bdb-72db-a4fd-db3fffa2d5e8","shared:/pulp/api/v3/domains/018eaac6-4bdb-72db-a4fd-db3fffa2d5e8/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -125,15 +125,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '656'
+      - '874'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0d86db03c7fa4293aca3af256c9a592a
+      - 4894ba4916c34adb834e4485a0b2617b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:42 GMT
+      - Thu, 04 Apr 2024 20:24:09 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -159,13 +159,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.10
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/","pulp_created":"2024-03-05T17:15:36.998019Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018e0f9d-16a5-73e6-a30d-cdac09ff569f/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018e0f9d-04b5-7b0d-ac02-5287da03f5dd/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/","pulp_created":"2024-04-04T20:23:51.463770Z","pulp_last_updated":"2024-04-04T20:24:08.746242Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018eaac8-35a5-7499-89ea-29e8cd1913c7/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/018eaac8-0cd7-7085-8c47-cc7a8e54e61f/","autopublish":true,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":"{\"gpgcheck\":
         0}","compression_type":null}'
     headers:
       Access-Control-Expose-Headers:
@@ -175,15 +175,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '815'
+      - '865'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0265490bf2774aa4b22b7697ba244841
+      - 186dd54667824a7085567a192d4b8f6c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Tue, 05 Mar 2024 17:15:42 GMT
+      - Thu, 04 Apr 2024 20:24:10 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/playbooks/rpm_repository.yaml
+++ b/tests/playbooks/rpm_repository.yaml
@@ -160,6 +160,52 @@
         that:
           - result.changed == false
 
+    - name: Add retain_package_versions to 3 in repository
+      pulp.squeezer.rpm_repository:
+        name: test_rpm_repository
+        retain_package_versions: 3
+        state: present
+      register: result
+    - name: Verify add retain_package_versions is 3 in repository
+      assert:
+        that:
+          - result.changed == true
+          - result.repository.retain_package_versions == 3
+
+    - name: Add retain_package_versions to 3 in repository (2nd try)
+      pulp.squeezer.rpm_repository:
+        name: test_rpm_repository
+        retain_package_versions: 3
+        state: present
+      register: result
+    - name: Verify add retain_package_versions is 3 in repository (2nd try)
+      assert:
+        that:
+          - result.changed == false
+
+    - name: Remove retain_package_versions to 3 from repository
+      pulp.squeezer.rpm_repository:
+        name: test_rpm_repository
+        retain_package_versions: 0
+        state: present
+      register: result
+    - name: Verify remove retain_package_versions to 3 from repository
+      assert:
+        that:
+          - result.changed == true
+          - result.repository.retain_package_versions == 0
+
+    - name: Remove retain_package_versions to 3 from repository (2nd try)
+      pulp.squeezer.rpm_repository:
+        name: test_rpm_repository
+        retain_package_versions: 0
+        state: present
+      register: result
+    - name: Verify remove retain_package_versions to 3 from repository (2nd try)
+      assert:
+        that:
+          - result.changed == false
+
     - name: Fake modify repository
       pulp.squeezer.rpm_repository:
         name: test_rpm_repository


### PR DESCRIPTION
Adding support for "retain_package_versions" at the rpm_repository level. Created tests inside "rpm_repository.yaml", mirroring what the current standard. Finally, refreshed the fixtures to reference the new tests. 

I've run the full set of tests and all are passing, 100%. 

Thanks,
Chris