### PR TITLE
#156 - Added skip_types and optimize options to rpm_sync

### DIFF
--- a/plugins/modules/rpm_sync.py
+++ b/plugins/modules/rpm_sync.py
@@ -36,6 +36,20 @@ options:
     required: false
     default: "additive"
     choices: ["additive", "mirror_complete", "mirror_content_only"]
+  skip_types:
+    description:
+      - List of content types to skip during sync.
+    type: list
+    required: false
+    elements: str
+    choices: ["srpm", "treeinfo"]
+  optimize:
+    description:
+      - Whether or not to optimize sync.
+    type: bool
+    required: false
+    default: true
+
 extends_documentation_fragment:
   - pulp.squeezer.pulp
 author:
@@ -83,6 +97,12 @@ def main():
                 default="additive",
                 choices=["additive", "mirror_complete", "mirror_content_only"],
             ),
+            skip_types=dict(
+                type="list",
+                elements="str",
+                choices=["srpm", "treeinfo"],
+            ),
+            optimize=dict(type="bool", default=True),
         ),
     ) as module:
         remote = PulpRpmRemote(module, {"name": module.params["remote"]})
@@ -105,6 +125,17 @@ def main():
         else:
             mirror = module.params["sync_policy"] == "mirror_complete"
             parameters = {"mirror": mirror}
+
+        parameters.update(
+            {
+                key: module.params[key]
+                for key in [
+                    "skip_types",
+                    "optimize",
+                ]
+                if module.params[key] is not None
+            }
+        )
 
         repository.process_sync(remote, parameters)
 

--- a/tests/fixtures/rpm_sync-1.yml
+++ b/tests/fixtures/rpm_sync-1.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.6
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/remotes/rpm/rpm/?limit=1&name=test_rpm_remote
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/55712a46-fb77-4c0a-ab06-198702b5db39/","pulp_created":"2021-11-11T14:30:38.578727Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-unsigned/","ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"pulp_labels":{},"pulp_last_updated":"2021-11-11T14:30:38.578745Z","download_concurrency":null,"max_retries":null,"policy":"immediate","total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"rate_limit":null,"sles_auth_token":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/018ee2b8-5af3-72dd-8601-3e9df47474c5/","pulp_created":"2024-04-15T17:05:16.532512Z","pulp_last_updated":"2024-04-15T17:05:16.532531Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-unsigned/","ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"pulp_labels":{},"download_concurrency":null,"max_retries":null,"policy":"immediate","total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"rate_limit":null,"hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"sles_auth_token":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,19 +25,21 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '620'
+      - '827'
       Content-Type:
       - application/json
       Correlation-ID:
-      - e287c6e18b4f4ef4abe82ee12c9344e5
+      - 0efade4d13f1401bbaadd22185e5c745
+      Cross-Origin-Opener-Policy:
+      - same-origin
       Date:
-      - Thu, 11 Nov 2021 14:30:53 GMT
+      - Mon, 15 Apr 2024 17:05:30 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.14.1
+      - nginx/1.22.1
       Vary:
-      - Accept, Cookie
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -57,12 +59,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.6
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/","pulp_created":"2021-11-11T14:30:37.772977Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/versions/1/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":null,"autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":0,"repo_gpgcheck":0,"sqlite_metadata":false}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/","pulp_created":"2024-04-15T17:05:14.574667Z","pulp_last_updated":"2024-04-15T17:05:27.154914Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/versions/1/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":null,"autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -71,19 +73,21 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '691'
+      - '809'
       Content-Type:
       - application/json
       Correlation-ID:
-      - d68c3e8c2fb9486d8ba70e7f37a41c17
+      - 64c27274507b4a0fb0b29d55e78fa27a
+      Cross-Origin-Opener-Policy:
+      - same-origin
       Date:
-      - Thu, 11 Nov 2021 14:30:53 GMT
+      - Mon, 15 Apr 2024 17:05:30 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.14.1
+      - nginx/1.22.1
       Vary:
-      - Accept, Cookie
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -92,26 +96,26 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"remote": "/pulp/api/v3/remotes/rpm/rpm/55712a46-fb77-4c0a-ab06-198702b5db39/",
-      "sync_policy": "additive"}'
+    body: '{"remote": "/pulp/api/v3/remotes/rpm/rpm/018ee2b8-5af3-72dd-8601-3e9df47474c5/",
+      "sync_policy": "additive", "skip_types": ["srpm", "treeinfo"], "optimize": true}'
     headers:
       Accept:
       - application/json
       Connection:
       - close
       Content-Length:
-      - 107
+      - 161
       Content-Type:
       - application/json
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.6
+      - Python-urllib/3.9
     method: POST
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/sync/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/sync/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/"}'
+      string: '{"task":"/pulp/api/v3/tasks/018ee2b8-95b7-74d4-abbc-a59a930e506a/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -124,15 +128,17 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7d4c85f7e22845e4897f601a22c6fec4
+      - 58879ca072a34e0480e95a8130cbae05
+      Cross-Origin-Opener-Policy:
+      - same-origin
       Date:
-      - Thu, 11 Nov 2021 14:30:53 GMT
+      - Mon, 15 Apr 2024 17:05:31 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.14.1
+      - nginx/1.22.1
       Vary:
-      - Accept, Cookie
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -152,12 +158,13 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.6
+      - Python-urllib/3.9
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/018ee2b8-95b7-74d4-abbc-a59a930e506a/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/","pulp_created":"2021-11-11T14:30:53.801962Z","state":"running","name":"pulp_rpm.app.tasks.synchronizing.synchronize","logging_cid":"7d4c85f7e22845e4897f601a22c6fec4","started_at":"2021-11-11T14:30:53.841866Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/32ffa6db-4978-4328-9e90-6790fdb4e8c8/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/","shared:/pulp/api/v3/remotes/rpm/rpm/55712a46-fb77-4c0a-ab06-198702b5db39/"]}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/018ee2b8-95b7-74d4-abbc-a59a930e506a/","pulp_created":"2024-04-15T17:05:31.576358Z","pulp_last_updated":"2024-04-15T17:05:31.576382Z","state":"completed","name":"pulp_rpm.app.tasks.synchronizing.synchronize","logging_cid":"58879ca072a34e0480e95a8130cbae05","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2024-04-15T17:05:31.599799Z","started_at":"2024-04-15T17:05:31.649589Z","finished_at":"2024-04-15T17:05:32.012585Z","error":null,"worker":"/pulp/api/v3/workers/018ee2b8-0ff5-7d1c-bbd8-690001ab7e40/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Skipping
+        Sync (no change from previous sync)","code":"sync.was_skipped","state":"completed","total":1,"done":1,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/","prn:rpm.rpmrepository:018ee2b8-534c-7476-843f-31206482de31","shared:prn:rpm.rpmremote:018ee2b8-5af3-72dd-8601-3e9df47474c5","shared:/pulp/api/v3/remotes/rpm/rpm/018ee2b8-5af3-72dd-8601-3e9df47474c5/","shared:prn:core.domain:018ee2b6-be2c-71aa-9c77-bd0758bd1e23","shared:/pulp/api/v3/domains/018ee2b6-be2c-71aa-9c77-bd0758bd1e23/"]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -166,112 +173,21 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '662'
+      - '1213'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 4b194c434c1d44bb962670c485c65458
+      - a922fbf8aa3040119f10ac830afc4f04
+      Cross-Origin-Opener-Policy:
+      - same-origin
       Date:
-      - Thu, 11 Nov 2021 14:30:54 GMT
+      - Mon, 15 Apr 2024 17:05:32 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.14.1
+      - nginx/1.22.1
       Vary:
-      - Accept, Cookie
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.6
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/","pulp_created":"2021-11-11T14:30:53.801962Z","state":"running","name":"pulp_rpm.app.tasks.synchronizing.synchronize","logging_cid":"7d4c85f7e22845e4897f601a22c6fec4","started_at":"2021-11-11T14:30:53.841866Z","finished_at":null,"error":null,"worker":"/pulp/api/v3/workers/32ffa6db-4978-4328-9e90-6790fdb4e8c8/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/","shared:/pulp/api/v3/remotes/rpm/rpm/55712a46-fb77-4c0a-ab06-198702b5db39/"]}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '662'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - caf4fceb05c14f86908466c3ccf96d2a
-      Date:
-      - Thu, 11 Nov 2021 14:30:56 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.14.1
-      Vary:
-      - Accept, Cookie
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Connection:
-      - close
-      Content-Type:
-      - application/json
-      Host:
-      - localhost:8080
-      User-Agent:
-      - Python-urllib/3.6
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/a7050aa6-f23f-4b0c-a264-3c71e110412a/","pulp_created":"2021-11-11T14:30:53.801962Z","state":"completed","name":"pulp_rpm.app.tasks.synchronizing.synchronize","logging_cid":"7d4c85f7e22845e4897f601a22c6fec4","started_at":"2021-11-11T14:30:53.841866Z","finished_at":"2021-11-11T14:30:57.781525Z","error":null,"worker":"/pulp/api/v3/workers/32ffa6db-4978-4328-9e90-6790fdb4e8c8/","parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[{"message":"Skipping
-        Sync (no change from previous sync)","code":"sync.was_skipped","state":"completed","total":1,"done":1,"suffix":null}],"created_resources":[],"reserved_resources_record":["/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/","shared:/pulp/api/v3/remotes/rpm/rpm/55712a46-fb77-4c0a-ab06-198702b5db39/"]}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - close
-      Content-Length:
-      - '826'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 0f509641e7914ea48a0a849a0b61704e
-      Date:
-      - Thu, 11 Nov 2021 14:30:58 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.14.1
-      Vary:
-      - Accept, Cookie
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/tests/fixtures/rpm_sync-2.yml
+++ b/tests/fixtures/rpm_sync-2.yml
@@ -11,12 +11,12 @@ interactions:
       Host:
       - localhost:8080
       User-Agent:
-      - Python-urllib/3.6
+      - Python-urllib/3.9
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?limit=1&name=test_rpm_repository
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/","pulp_created":"2021-11-11T14:30:37.772977Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/23d4e50f-fab1-49c0-96aa-814daca7ed40/versions/1/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":null,"autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":0,"repo_gpgcheck":0,"sqlite_metadata":false}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/","pulp_created":"2024-04-15T17:05:14.574667Z","pulp_last_updated":"2024-04-15T17:05:27.154914Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/018ee2b8-534c-7476-843f-31206482de31/versions/1/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"remote":null,"autopublish":false,"metadata_signing_service":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"gpgcheck":null,"repo_gpgcheck":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -25,19 +25,21 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '691'
+      - '809'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 23de661a450d4d509ea6d3beef950487
+      - 3d76464f192d4b46a0a41c4035a2da51
+      Cross-Origin-Opener-Policy:
+      - same-origin
       Date:
-      - Thu, 11 Nov 2021 14:30:59 GMT
+      - Mon, 15 Apr 2024 17:05:33 GMT
       Referrer-Policy:
       - same-origin
       Server:
-      - nginx/1.14.1
+      - nginx/1.22.1
       Vary:
-      - Accept, Cookie
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/tests/playbooks/rpm_sync.yaml
+++ b/tests/playbooks/rpm_sync.yaml
@@ -43,6 +43,9 @@
       pulp.squeezer.rpm_sync:
         remote: test_rpm_remote
         repository: test_rpm_repository
+        optimize: true
+        skip_types: ['srpm', 'treeinfo']
+        sync_policy: additive
       register: result
     - name: Verify sync remote into repository
       assert:
@@ -55,6 +58,9 @@
       pulp.squeezer.rpm_sync:
         remote: test_rpm_remote
         repository: test_rpm_repository
+        optimize: true
+        skip_types: ['srpm', 'treeinfo']
+        sync_policy: additive
       register: result
     - name: Verify sync remote into repository (2nd try)
       assert:


### PR DESCRIPTION
#156 

Adding support for "skip_types" and "optimize" options to rpm_sync. Created tests inside "rpm_sync.yaml". Finally, refreshed the fixtures to reference the new tests.

I've run the full set of tests and all are passing, 100%.

Thanks,
Chris