### PR TITLE
feat: add timeout for container sync

### DIFF
--- a/plugins/modules/container_sync.py
+++ b/plugins/modules/container_sync.py
@@ -27,6 +27,8 @@ options:
       - Name of the repository
     type: str
     required: true
+  timeout:
+    default: 3600
 extends_documentation_fragment:
   - pulp.squeezer.pulp.glue
   - pulp.squeezer.pulp
@@ -80,6 +82,7 @@ def main():
         argument_spec=dict(
             remote=dict(required=False),
             repository=dict(required=True),
+            timeout=dict(type="int", default=3600),
         ),
     ) as module:
         repository_ctx = PulpContainerRepositoryContext(


### PR DESCRIPTION
As written in [issues/135](https://github.com/pulp/squeezer/issues/135) ansible_sync module is failing due timeouts and has been resolved with [PR#136](https://github.com/pulp/squeezer/pull/136). However this problem appears to impact other modules as mentioned in [issues/148](https://github.com/pulp/squeezer/issues/148).

I have encountered this problem with container_sync with repeated timeouts. Apply the same fix as found in [PR#136](https://github.com/pulp/squeezer/pull/136) has resolved all timeouts.