### PR TITLE
A 'repository' keyword to `python_distribution` module

### DIFF
--- a/plugins/modules/python_distribution.py
+++ b/plugins/modules/python_distribution.py
@@ -128,7 +128,7 @@ def main():
     with PulpEntityAnsibleModule(
         context_class=PulpPythonDistributionContext,
         entity_singular="distribution",
-        entity_plural="distribuions",
+        entity_plural="distributions",
         import_errors=[("pulp-glue", PULP_CLI_IMPORT_ERR)],
         argument_spec=dict(
             name=dict(),

--- a/tests/playbooks/python_distribution.yaml
+++ b/tests/playbooks/python_distribution.yaml
@@ -224,6 +224,52 @@
           - ansible_check_mode or result.distribution.base_url is regex(".*/pypi/pull_through_mirror")
           - result.distribution.remote == ""
 
+    - name: Retrieve repository
+      pulp.squeezer.python_repository:
+        name: test_python_repository
+      register: repository_result
+
+    - name: Distribute latest version of repository
+      pulp.squeezer.python_distribution:
+        name: test_python_distribution
+        base_path: test_python_base_path
+        repository: test_python_repository
+        state: present
+      register: result
+    - name: Verify distribute latest version of repository
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.distribution.name == "test_python_distribution"
+          - result.distribution.base_path == "test_python_base_path"
+          - ansible_check_mode or result.distribution.base_url is regex(".*/pypi/test_python_base_path")
+          - result.distribution.repository == repository_result.repository.pulp_href
+
+    - name: Distribute publication of repository (2nd try)
+      pulp.squeezer.python_distribution:
+        name: test_python_distribution
+        base_path: test_python_base_path
+        repository: test_python_repository
+        state: present
+      register: result
+    - name: Verify distribute publication of repository (2nd try)
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+
+    - name: Read distribution
+      pulp.squeezer.python_distribution:
+        name: test_python_distribution
+      register: result
+    - name: Verify read distribution
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.distribution.name == "test_python_distribution"
+          - result.distribution.base_path == "test_python_base_path"
+          - result.distribution.base_url is regex(".*/pypi/test_python_base_path")
+          - result.distribution.repository == repository_result.repository.pulp_href
+
 - hosts: localhost
   gather_facts: false
   vars_files:


### PR DESCRIPTION
Many Pulp plugins allow a distribution to track the latest RepositoryVersion of a repository. This PR adds support for that functionality to the `python_distribution` module.

This makes maintaining custom Python repositories easier by not having to retrieve and update the latest publication to distribute. The repository is immediately updated when a developer uploads an updated Python package to the repository. Decreasing the effort required, by Ansible and me, to squeeze my Pulp into shape. :wink: 

I hope everything is up to par, otherwise please point out or explain to me the areas I need to patch up and I will have a look at it as soon as I am able.