### PR TITLE
added gpgkey parameter to deb_remote module

### DIFF
--- a/plugins/modules/deb_remote.py
+++ b/plugins/modules/deb_remote.py
@@ -23,6 +23,10 @@ options:
     description:
       - Whitespace separated list of distributions to sync.
     type: str
+  gpgkey:
+    description:
+      - gpgkey of remote repository
+    type: str
   policy:
     description:
       - Whether downloads should be performed immediately, or lazy.
@@ -111,6 +115,7 @@ def main():
             "architectures": {},
             "components": {},
             "distributions": {},
+            "gpgkey": {},
             "policy": {"choices": ["immediate", "on_demand", "streamed"]},
             "sync_installer": {"type": "bool"},
             "sync_sources": {"type": "bool"},
@@ -127,6 +132,7 @@ def main():
                 "components",
                 "distributions",
                 "download_concurrency",
+                "gpgkey",
                 "policy",
                 "sync_installer",
                 "sync_sources",


### PR DESCRIPTION
The deb_remote module lacks a gpgkey parameter, which is crucial for me. So i tried to implement it.

At this time, once a gpgkey is set, there is no option to set it to null. I have been unable to determine how to do so. I would appreciate assistance with this matter.