### PR TITLE
Sven vd be patch 1

### DIFF
--- a/plugins/module_utils/pulp_glue.py
+++ b/plugins/module_utils/pulp_glue.py
@@ -10,7 +10,7 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback, missing_required_lib
 
-GLUE_VERSION_SPEC = ">=0.29.2,<0.32"
+GLUE_VERSION_SPEC = ">=0.29.2,<=0.32.1"
 GLUE_DEB_VERSION_SPEC = ">=0.3.0,<0.4"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pulp-glue<0.32,>=0.29.2
+pulp-glue<=0.32.1,>=0.29.2
 pulp-glue-deb<0.4.0,>=0.3.0
 
 ansible_runner<2.3; python_version < '3.7'


### PR DESCRIPTION
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: Installed 'pulp-glue' version '0.32.1' is not in '>=0.29.2,<0.32'.