### PR TITLE
Add support for pulp_labels key to file_repository

### DIFF
--- a/plugins/modules/file_repository.py
+++ b/plugins/modules/file_repository.py
@@ -23,6 +23,11 @@ options:
     description:
       - Whether to automatically create publications for new repository versions
     type: bool
+  pulp_labels:
+    description:
+      - A dictionary assigning pulp labels using string keys and values
+    type: dict
+    version_added: "0.4.0"
 extends_documentation_fragment:
   - pulp.squeezer.pulp.entity_state
   - pulp.squeezer.pulp
@@ -86,6 +91,7 @@ except ImportError:
 DESIRED_KEYS = {
     "autopublish",
     "description",
+    "pulp_labels",
 }
 
 
@@ -99,6 +105,7 @@ def main():
             "name": {},
             "description": {},
             "autopublish": {"type": "bool"},
+            "pulp_labels": {"type": "dict"},
         },
         required_if=[("state", "present", ["name"]), ("state", "absent", ["name"])],
     ) as module:
@@ -106,6 +113,14 @@ def main():
         desired_attributes = {
             key: module.params[key] for key in DESIRED_KEYS if module.params[key] is not None
         }
+
+        # Ensure `pulp_labels` contains only strings for keys and values
+        if "pulp_labels" in desired_attributes:
+            labels = desired_attributes["pulp_labels"]
+            if not all(isinstance(k, str) and isinstance(v, str) for k, v in labels.items()):
+                module.fail_json(
+                    msg="pulp_labels must be a dictionary with strings as keys and values"
+                )
 
         module.process(natural_key, desired_attributes)
 

--- a/plugins/modules/rpm_repository.py
+++ b/plugins/modules/rpm_repository.py
@@ -169,7 +169,9 @@ def main():
         if "pulp_labels" in desired_attributes:
             labels = desired_attributes["pulp_labels"]
             if not all(isinstance(k, str) and isinstance(v, str) for k, v in labels.items()):
-                module.fail_json(msg="pulp_labels must be a dictionary with strings as keys and values")
+                module.fail_json(
+                    msg="pulp_labels must be a dictionary with strings as keys and values"
+                )
 
         module.process(natural_key, desired_attributes)
 

--- a/tests/fixtures/file_repository-0.yml
+++ b/tests/fixtures/file_repository-0.yml
@@ -17,7 +17,7 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/docs/api.json
   response:
@@ -30,13 +30,13 @@ interactions:
         {\n            \"url\": \"https://raw.githubusercontent.com/pulp/pulpcore/master/LICENSE\",\n
         \           \"name\": \"GNU General Public License v2.0 or later\"\n        },\n
         \       \"x-logo\": {\n            \"url\": \"https://pulpproject.org/assets/pulp_logo_icon.svg\"\n
-        \       },\n        \"x-pulp-app-versions\": {\n            \"core\": \"3.109.1\",\n
-        \           \"ansible\": \"0.29.7\",\n            \"container\": \"2.27.6\",\n
-        \           \"deb\": \"3.8.1\",\n            \"gem\": \"0.7.5\",\n            \"hugging_face\":
-        \"0.3.0\",\n            \"maven\": \"0.12.0\",\n            \"npm\": \"0.7.1\",\n
-        \           \"ostree\": \"2.6.0\",\n            \"python\": \"3.29.0\",\n
-        \           \"rpm\": \"3.36.0\",\n            \"certguard\": \"3.109.1\",\n
-        \           \"file\": \"3.109.1\"\n        },\n        \"x-pulp-domain-enabled\":
+        \       },\n        \"x-pulp-app-versions\": {\n            \"core\": \"3.111.1\",\n
+        \           \"ansible\": \"0.29.8\",\n            \"container\": \"2.27.9\",\n
+        \           \"deb\": \"3.8.2\",\n            \"gem\": \"0.7.5\",\n            \"hugging_face\":
+        \"0.3.0\",\n            \"maven\": \"0.12.0\",\n            \"npm\": \"0.8.0\",\n
+        \           \"ostree\": \"2.6.0\",\n            \"python\": \"3.30.0\",\n
+        \           \"rpm\": \"3.36.0\",\n            \"certguard\": \"3.111.1\",\n
+        \           \"file\": \"3.111.1\"\n        },\n        \"x-pulp-domain-enabled\":
         false\n    },\n    \"paths\": {\n        \"/ansible/collections/\": {\n            \"post\":
         {\n                \"operationId\": \"upload_collection\",\n                \"description\":
         \"Create an artifact and trigger an asynchronous task to create Collection
@@ -64,10 +64,88 @@ interactions:
         \"#/components/schemas/AsyncOperationResponse\"\n                                }\n
         \                           }\n                        },\n                        \"description\":
         \"\"\n                    }\n                }\n            }\n        },\n
-        \       \"/pulp/api/v3/access_policies/\": {\n            \"get\": {\n                \"operationId\":
-        \"access_policies_list\",\n                \"description\": \"ViewSet for
-        AccessPolicy.\",\n                \"summary\": \"List access policys\",\n
-        \               \"parameters\": [\n                    {\n                        \"in\":
+        \       \"/npm/{path}/{package_name}\": {\n            \"put\": {\n                \"operationId\":
+        \"npm_put\",\n                \"description\": \"Handle npm/yarn publish requests
+        (``PUT /``).\",\n                \"parameters\": [\n                    {\n
+        \                       \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"package_name\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^@[^/]+%2[Ff][^/]+|@[^/]+/[^/]+|[^/@][^/]*$\"\n
+        \                       },\n                        \"required\": true\n                    },\n
+        \                   {\n                        \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    }\n                ],\n
+        \               \"tags\": [\n                    \"Npm\"\n                ],\n
+        \               \"security\": [\n                    {\n                        \"basicAuth\":
+        []\n                    },\n                    {\n                        \"cookieAuth\":
+        []\n                    }\n                ],\n                \"responses\":
+        {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/npm/{path}/-/ping\": {\n            \"get\": {\n                \"operationId\":
+        \"npm___ping_get\",\n                \"description\": \"Handle ``GET /-/ping``
+        -- registry health check.\",\n                \"parameters\": [\n                    {\n
+        \                       \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to include in the response.\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to exclude from the response.\"\n                    }\n
+        \               ],\n                \"tags\": [\n                    \"Npm:
+        Ping\"\n                ],\n                \"security\": [\n                    {\n
+        \                       \"basicAuth\": []\n                    },\n                    {\n
+        \                       \"cookieAuth\": []\n                    }\n                ],\n
+        \               \"responses\": {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/npm/{path}/-/whoami\": {\n            \"get\": {\n
+        \               \"operationId\": \"npm___whoami_get\",\n                \"description\":
+        \"Handle ``GET /-/whoami`` -- return the authenticated user.\",\n                \"parameters\":
+        [\n                    {\n                        \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to include in the response.\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to exclude from the response.\"\n                    }\n
+        \               ],\n                \"tags\": [\n                    \"Npm:
+        Whoami\"\n                ],\n                \"security\": [\n                    {\n
+        \                       \"basicAuth\": []\n                    },\n                    {\n
+        \                       \"cookieAuth\": []\n                    }\n                ],\n
+        \               \"responses\": {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/pulp/api/v3/access_policies/\": {\n            \"get\":
+        {\n                \"operationId\": \"access_policies_list\",\n                \"description\":
+        \"ViewSet for AccessPolicy.\",\n                \"summary\": \"List access
+        policys\",\n                \"parameters\": [\n                    {\n                        \"in\":
         \"header\",\n                        \"name\": \"X-Task-Diagnostics\",\n                        \"schema\":
         {\n                            \"type\": \"array\",\n                            \"items\":
         {\n                                \"type\": \"string\"\n                            }\n
@@ -48899,25 +48977,83 @@ interactions:
         \"array\",\n                            \"items\": {\n                                \"type\":
         \"string\"\n                            }\n                        },\n                        \"description\":
         \"List of profilers to use on tasks.\"\n                    },\n                    {\n
-        \                       \"name\": \"limit\",\n                        \"required\":
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"filename\",\n                        \"schema\": {\n                            \"type\":
+        \"string\"\n                        },\n                        \"description\":
+        \"Filter results where filename matches value\"\n                    },\n
+        \                   {\n                        \"name\": \"limit\",\n                        \"required\":
         false,\n                        \"in\": \"query\",\n                        \"description\":
         \"Number of results to return per page.\",\n                        \"schema\":
         {\n                            \"type\": \"integer\"\n                        }\n
-        \                   },\n                    {\n                        \"name\":
+        \                   },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"name\",\n                        \"schema\":
+        {\n                            \"type\": \"string\"\n                        },\n
+        \                       \"description\": \"Filter results where name matches
+        value\"\n                    },\n                    {\n                        \"name\":
         \"offset\",\n                        \"required\": false,\n                        \"in\":
         \"query\",\n                        \"description\": \"The initial index from
         which to return the results.\",\n                        \"schema\": {\n                            \"type\":
         \"integer\"\n                        }\n                    },\n                    {\n
-        \                       \"in\": \"path\",\n                        \"name\":
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"ordering\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\",\n                                \"enum\": [\n                                    \"-added_by\",\n
+        \                                   \"-filename\",\n                                    \"-name\",\n
+        \                                   \"-pk\",\n                                    \"-pulp_created\",\n
+        \                                   \"-pulp_id\",\n                                    \"-pulp_last_updated\",\n
+        \                                   \"-version\",\n                                    \"added_by\",\n
+        \                                   \"filename\",\n                                    \"name\",\n
+        \                                   \"pk\",\n                                    \"pulp_created\",\n
+        \                                   \"pulp_id\",\n                                    \"pulp_last_updated\",\n
+        \                                   \"version\"\n                                ]\n
+        \                           }\n                        },\n                        \"description\":
+        \"Ordering\\n\\n* `pulp_id` - Pulp id\\n* `-pulp_id` - Pulp id (descending)\\n*
+        `pulp_created` - Pulp created\\n* `-pulp_created` - Pulp created (descending)\\n*
+        `pulp_last_updated` - Pulp last updated\\n* `-pulp_last_updated` - Pulp last
+        updated (descending)\\n* `name` - Name\\n* `-name` - Name (descending)\\n*
+        `version` - Version\\n* `-version` - Version (descending)\\n* `filename` -
+        Filename\\n* `-filename` - Filename (descending)\\n* `added_by` - Added by\\n*
+        `-added_by` - Added by (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n
+        \                       \"explode\": false,\n                        \"style\":
+        \"form\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"prn__in\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"pulp_href__in\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"Multiple values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"pulp_id__in\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\",\n                                \"format\": \"uuid\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"path\",\n                        \"name\":
         \"python_python_repository_href\",\n                        \"schema\": {\n
         \                           \"type\": \"string\"\n                        },\n
         \                       \"required\": true\n                    },\n                    {\n
         \                       \"in\": \"query\",\n                        \"name\":
-        \"fields\",\n                        \"schema\": {\n                            \"type\":
-        \"array\",\n                            \"items\": {\n                                \"type\":
-        \"string\"\n                            }\n                        },\n                        \"description\":
-        \"A list of fields to include in the response.\"\n                    },\n
-        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"q\",\n                        \"schema\": {\n                            \"type\":
+        \"string\"\n                        },\n                        \"description\":
+        \"Filter results by using NOT, AND and OR operations on other filters\"\n
+        \                   },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"version\",\n                        \"schema\":
+        {\n                            \"type\": \"string\"\n                        },\n
+        \                       \"description\": \"Filter results where version matches
+        value\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"fields\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"A list
+        of fields to include in the response.\"\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
         \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
         \"array\",\n                            \"items\": {\n                                \"type\":
         \"string\"\n                            }\n                        },\n                        \"description\":
@@ -50977,10 +51113,12 @@ interactions:
         \                                   \"-name\",\n                                    \"-next_dispatch\",\n
         \                                   \"-pk\",\n                                    \"-pulp_created\",\n
         \                                   \"-pulp_id\",\n                                    \"-pulp_last_updated\",\n
+        \                                   \"-task_args\",\n                                    \"-task_kwargs\",\n
         \                                   \"-task_name\",\n                                    \"dispatch_interval\",\n
         \                                   \"name\",\n                                    \"next_dispatch\",\n
         \                                   \"pk\",\n                                    \"pulp_created\",\n
         \                                   \"pulp_id\",\n                                    \"pulp_last_updated\",\n
+        \                                   \"task_args\",\n                                    \"task_kwargs\",\n
         \                                   \"task_name\"\n                                ]\n
         \                           }\n                        },\n                        \"description\":
         \"Ordering\\n\\n* `pulp_id` - Pulp id\\n* `-pulp_id` - Pulp id (descending)\\n*
@@ -50990,7 +51128,9 @@ interactions:
         `next_dispatch` - Next dispatch\\n* `-next_dispatch` - Next dispatch (descending)\\n*
         `dispatch_interval` - Dispatch interval\\n* `-dispatch_interval` - Dispatch
         interval (descending)\\n* `task_name` - Task name\\n* `-task_name` - Task
-        name (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n                        \"explode\":
+        name (descending)\\n* `task_args` - Task args\\n* `-task_args` - Task args
+        (descending)\\n* `task_kwargs` - Task kwargs\\n* `-task_kwargs` - Task kwargs
+        (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n                        \"explode\":
         false,\n                        \"style\": \"form\"\n                    },\n
         \                   {\n                        \"in\": \"query\",\n                        \"name\":
         \"prn__in\",\n                        \"schema\": {\n                            \"type\":
@@ -52349,21 +52489,27 @@ interactions:
         {\n                                \"type\": \"string\",\n                                \"enum\":
         [\n                                    \"-api_root\",\n                                    \"-base_url\",\n
         \                                   \"-ca_cert\",\n                                    \"-client_cert\",\n
-        \                                   \"-client_key\",\n                                    \"-domain\",\n
-        \                                   \"-last_replication\",\n                                    \"-name\",\n
-        \                                   \"-password\",\n                                    \"-pk\",\n
-        \                                   \"-policy\",\n                                    \"-pulp_created\",\n
-        \                                   \"-pulp_id\",\n                                    \"-pulp_last_updated\",\n
-        \                                   \"-q_select\",\n                                    \"-tls_validation\",\n
+        \                                   \"-client_key\",\n                                    \"-connect_timeout\",\n
+        \                                   \"-domain\",\n                                    \"-download_concurrency\",\n
+        \                                   \"-last_replication\",\n                                    \"-max_retries\",\n
+        \                                   \"-name\",\n                                    \"-password\",\n
+        \                                   \"-pk\",\n                                    \"-policy\",\n
+        \                                   \"-pulp_created\",\n                                    \"-pulp_id\",\n
+        \                                   \"-pulp_last_updated\",\n                                    \"-q_select\",\n
+        \                                   \"-sock_connect_timeout\",\n                                    \"-sock_read_timeout\",\n
+        \                                   \"-tls_validation\",\n                                    \"-total_timeout\",\n
         \                                   \"-username\",\n                                    \"api_root\",\n
         \                                   \"base_url\",\n                                    \"ca_cert\",\n
         \                                   \"client_cert\",\n                                    \"client_key\",\n
-        \                                   \"domain\",\n                                    \"last_replication\",\n
-        \                                   \"name\",\n                                    \"password\",\n
-        \                                   \"pk\",\n                                    \"policy\",\n
-        \                                   \"pulp_created\",\n                                    \"pulp_id\",\n
-        \                                   \"pulp_last_updated\",\n                                    \"q_select\",\n
-        \                                   \"tls_validation\",\n                                    \"username\"\n
+        \                                   \"connect_timeout\",\n                                    \"domain\",\n
+        \                                   \"download_concurrency\",\n                                    \"last_replication\",\n
+        \                                   \"max_retries\",\n                                    \"name\",\n
+        \                                   \"password\",\n                                    \"pk\",\n
+        \                                   \"policy\",\n                                    \"pulp_created\",\n
+        \                                   \"pulp_id\",\n                                    \"pulp_last_updated\",\n
+        \                                   \"q_select\",\n                                    \"sock_connect_timeout\",\n
+        \                                   \"sock_read_timeout\",\n                                    \"tls_validation\",\n
+        \                                   \"total_timeout\",\n                                    \"username\"\n
         \                               ]\n                            }\n                        },\n
         \                       \"description\": \"Ordering\\n\\n* `pulp_id` - Pulp
         id\\n* `-pulp_id` - Pulp id (descending)\\n* `pulp_created` - Pulp created\\n*
@@ -52377,16 +52523,24 @@ interactions:
         - Client key\\n* `-client_key` - Client key (descending)\\n* `tls_validation`
         - Tls validation\\n* `-tls_validation` - Tls validation (descending)\\n* `username`
         - Username\\n* `-username` - Username (descending)\\n* `password` - Password\\n*
-        `-password` - Password (descending)\\n* `q_select` - Q select\\n* `-q_select`
-        - Q select (descending)\\n* `policy` - Policy\\n* `-policy` - Policy (descending)\\n*
-        `last_replication` - Last replication\\n* `-last_replication` - Last replication
-        (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n                        \"explode\":
-        false,\n                        \"style\": \"form\"\n                    },\n
-        \                   {\n                        \"in\": \"query\",\n                        \"name\":
-        \"prn__in\",\n                        \"schema\": {\n                            \"type\":
-        \"array\",\n                            \"items\": {\n                                \"type\":
-        \"string\"\n                            }\n                        },\n                        \"description\":
-        \"Multiple values may be separated by commas.\",\n                        \"explode\":
+        `-password` - Password (descending)\\n* `download_concurrency` - Download
+        concurrency\\n* `-download_concurrency` - Download concurrency (descending)\\n*
+        `max_retries` - Max retries\\n* `-max_retries` - Max retries (descending)\\n*
+        `total_timeout` - Total timeout\\n* `-total_timeout` - Total timeout (descending)\\n*
+        `connect_timeout` - Connect timeout\\n* `-connect_timeout` - Connect timeout
+        (descending)\\n* `sock_connect_timeout` - Sock connect timeout\\n* `-sock_connect_timeout`
+        - Sock connect timeout (descending)\\n* `sock_read_timeout` - Sock read timeout\\n*
+        `-sock_read_timeout` - Sock read timeout (descending)\\n* `q_select` - Q select\\n*
+        `-q_select` - Q select (descending)\\n* `policy` - Policy\\n* `-policy` -
+        Policy (descending)\\n* `last_replication` - Last replication\\n* `-last_replication`
+        - Last replication (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n
+        \                       \"explode\": false,\n                        \"style\":
+        \"form\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"prn__in\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
         false,\n                        \"style\": \"form\"\n                    },\n
         \                   {\n                        \"in\": \"query\",\n                        \"name\":
         \"pulp_href__in\",\n                        \"schema\": {\n                            \"type\":
@@ -58570,49 +58724,48 @@ interactions:
         \               ]\n            },\n            \"ArtifactDistributionResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for ArtifactDistribution.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"pulp_created\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of creation.\"\n                    },\n                    \"pulp_last_updated\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of the last time this resource was updated. Note: for immutable
-        resources - like content, repository versions, and publication - pulp_created
-        and pulp_last_updated dates will be the same.\"\n                    },\n
-        \                   \"no_content_change_since\": {\n                        \"type\":
+        {\n                    \"no_content_change_since\": {\n                        \"type\":
         \"string\",\n                        \"readOnly\": true,\n                        \"description\":
         \"Timestamp since when the distributed content served by this distribution
         has not changed. If equals to `null`, no guarantee is provided about content
-        changes.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"An optional content-guard.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"name\":
+        changes.\"\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"base_path\":
         {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"description\": \"The base (relative) path component
-        of the published url. Avoid paths that                     overlap with other
-        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
-        \                   \"repository_version\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"RepositoryVersion to be
-        served\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"base_url\":
+        \"The base (relative) path component of the published url. Avoid paths that
+        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"base_url\":
         {\n                        \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"The URL for accessing the
-        publication as defined by this distribution.\"\n                    }\n                },\n
+        publication as defined by this distribution.\"\n                    },\n                    \"content_guard_prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
+        of the associated optional content guard.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"An optional content-guard.\"\n                    },\n                    \"pulp_created\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of creation.\"\n                    },\n                    \"repository_version\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"RepositoryVersion to be served\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"pulp_href\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"pulp_last_updated\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of the last time
+        this resource was updated. Note: for immutable resources - like content, repository
+        versions, and publication - pulp_created and pulp_last_updated dates will
+        be the same.\"\n                    },\n                    \"hidden\": {\n
+        \                       \"type\": \"boolean\",\n                        \"default\":
+        false,\n                        \"description\": \"Whether this distribution
+        should be shown in the content app.\"\n                    }\n                },\n
         \               \"required\": [\n                    \"base_path\",\n                    \"name\"\n
         \               ]\n            },\n            \"ArtifactRefResponse\": {\n
         \               \"type\": \"object\",\n                \"description\": \"A
@@ -59309,30 +59462,35 @@ interactions:
         `windows` - windows\\n* `macos` - macos\\n* `freebsd` - freebsd\\n* `linux`
         - linux\"\n            },\n            \"FileContentUpload\": {\n                \"type\":
         \"object\",\n                \"description\": \"Serializer for File Content.\",\n
-        \               \"properties\": {\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        \               \"properties\": {\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -60079,31 +60237,36 @@ interactions:
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for synchronous npm package uploads.\\n\\nHandles file-to-artifact
         conversion and metadata extraction in a single\\nrequest instead of dispatching
-        an async task.\",\n                \"properties\": {\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path. If not provided, it will be computed
-        from name and version.\"\n                    },\n                    \"file\":
+        an async task.\",\n                \"properties\": {\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path.
+        If not provided, it will be computed from name and version.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -60315,13 +60478,19 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -63029,7 +63198,36 @@ interactions:
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to be used for
         authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"q_select\":
+        are not trimmed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"q_select\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"description\": \"Filter distributions on
         the upstream Pulp using complex filtering. E.g. pulp_label_select=\\\"foo\\\"
@@ -63075,6 +63273,12 @@ interactions:
         \                   \"content_guard\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
         true,\n                        \"description\": \"An optional content-guard.\"\n
+        \                   },\n                    \"hidden\": {\n                        \"type\":
+        \"boolean\",\n                        \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
         \                   },\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
@@ -63084,17 +63288,13 @@ interactions:
         \                   \"repository_version\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
         true,\n                        \"description\": \"RepositoryVersion to be
-        served\"\n                    },\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    }\n                }\n
-        \           },\n            \"Patchedansible.AnsibleNamespaceMetadata\": {\n
-        \               \"type\": \"object\",\n                \"description\": \"A
-        serializer for Namespaces.\",\n                \"properties\": {\n                    \"name\":
+        served\"\n                    }\n                }\n            },\n            \"Patchedansible.AnsibleNamespaceMetadata\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"A serializer for Namespaces.\",\n                \"properties\": {\n                    \"name\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         3,\n                        \"description\": \"Required named, only accepts
         lowercase, numbers and underscores.\",\n                        \"maxLength\":
-        64,\n                        \"pattern\": \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n
+        64,\n                        \"pattern\": \"^(?!.*__)[a-z][0-9a-z_]*$\"\n
         \                   },\n                    \"company\": {\n                        \"type\":
         \"string\",\n                        \"description\": \"Optional namespace
         company owner.\",\n                        \"maxLength\": 64\n                    },\n
@@ -63252,52 +63452,59 @@ interactions:
         that have a signature\"\n                    }\n                }\n            },\n
         \           \"Patchedansible.GitRemote\": {\n                \"type\": \"object\",\n
         \               \"description\": \"A serializer for Git Collection Remotes.\",\n
-        \               \"properties\": {\n                    \"sock_read_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"client_key\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        \               \"properties\": {\n                    \"client_key\": {\n
+        \                       \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"A PEM encoded private key used
-        for authentication.\"\n                    },\n                    \"proxy_password\":
+        for authentication.\"\n                    },\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"proxy_password\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to authenticate
         to the proxy. Extra leading and trailing whitespace characters are not trimmed.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"client_cert\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
-        \                   \"proxy_username\": {\n                        \"type\":
+        \                   },\n                    \"password\": {\n                        \"type\":
         \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"The username to authenticte to the proxy.\"\n                    },\n                    \"connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"The password to be used for authentication when syncing. Extra leading and
+        trailing whitespace characters are not trimmed.\"\n                    },\n
+        \                   \"ca_cert\": {\n                        \"type\": \"string\",\n
+        \                       \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A PEM encoded CA certificate
+        used to validate the server certificate presented by the remote server.\"\n
+        \                   },\n                    \"connect_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"sock_connect_timeout\": {\n
+        \                       \"type\": \"number\",\n                        \"format\":
         \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
         (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"tls_validation\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        default from the aiohttp library to be used.\"\n                    },\n                    \"url\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The URL of an external content
+        source.\"\n                    },\n                    \"username\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to be used for authentication when syncing.\"\n                    },\n
         \                   \"headers\": {\n                        \"type\": \"array\",\n
         \                       \"items\": {\n                            \"type\":
         \"object\"\n                        },\n                        \"description\":
-        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"password\":
+        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"client_cert\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"A unique name for this remote.\"\n                    },\n                    \"proxy_username\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The password to be used for
-        authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"total_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_url\":
+        1,\n                        \"description\": \"The username to authenticte
+        to the proxy.\"\n                    },\n                    \"proxy_url\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"download_concurrency\":
@@ -63305,35 +63512,29 @@ interactions:
         \"int64\",\n                        \"nullable\": true,\n                        \"description\":
         \"Total number of simultaneous connections. If not set then the default value
         will be used.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"ca_cert\": {\n                        \"type\": \"string\",\n
-        \                       \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded CA certificate
-        used to validate the server certificate presented by the remote server.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this remote.\"\n                    },\n                    \"url\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The URL of an external content
-        source.\"\n                    },\n                    \"max_retries\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Maximum number of retry attempts after a download failure. If not set then
-        the default value (3) will be used.\"\n                    },\n                    \"username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to be used for
-        authentication when syncing.\"\n                    },\n                    \"sock_connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"metadata_only\":
+        \                   \"rate_limit\": {\n                        \"type\": \"integer\",\n
+        \                       \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Limits requests per second
+        for each concurrent downloader\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"tls_validation\":
         {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, only metadata about the content will be stored in Pulp. Clients
-        will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"sock_read_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"total_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"metadata_only\": {\n                        \"type\":
+        \"boolean\",\n                        \"description\": \"If True, only metadata
+        about the content will be stored in Pulp. Clients will retrieve content from
+        the remote URL.\"\n                    },\n                    \"git_ref\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"A git ref. e.g.: branch, tag,
         or commit sha.\"\n                    }\n                }\n            },\n
@@ -63450,65 +63651,67 @@ interactions:
         \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerDistribution\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for ContainerDistribution.\",\n                \"properties\":
-        {\n                    \"hidden\": {\n                        \"type\": \"boolean\",\n
-        \                       \"default\": false,\n                        \"description\":
-        \"Whether this distribution should be shown in the content app.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
+        {\n                    \"base_path\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
+        \"The base (relative) path component of the published url. Avoid paths that
+        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"A unique name. Ex, `rawhide`
+        and `stable`.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"private\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"Restrict pull access to explicitly authorized users. Defaults to unrestricted
-        pull access.\"\n                    },\n                    \"description\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"An optional description.\"\n                    }\n                }\n            },\n
-        \           \"Patchedcontainer.ContainerPullThroughDistribution\": {\n                \"type\":
-        \"object\",\n                \"description\": \"A serializer for a specialized
-        pull-through distribution referencing sub-distributions.\",\n                \"properties\":
-        {\n                    \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
         \                       \"default\": false,\n                        \"description\":
         \"Whether this distribution should be shown in the content app.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
+        \                   \"private\": {\n                        \"type\": \"boolean\",\n
+        \                       \"description\": \"Restrict pull access to explicitly
+        authorized users. Defaults to unrestricted pull access.\"\n                    },\n
+        \                   \"description\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"An optional description.\"\n
+        \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerPullThroughDistribution\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
+        \               \"properties\": {\n                    \"base_path\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"remote\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Remote that can be used
-        to fetch content when using pull-through caching.\"\n                    },\n
-        \                   \"distributions\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"remote\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Remote that can be used to fetch content when using pull-through caching.\"\n
+        \                   },\n                    \"distributions\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"type\":
         \"string\",\n                            \"format\": \"uri\"\n                        },\n
         \                       \"description\": \"Distributions created after pulling
@@ -63622,28 +63825,27 @@ interactions:
         \           },\n            \"Patchedcontainer.ContainerPushRepository\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"retain_checkpoints\": {\n                        \"type\":
+        {\n                    \"retain_repo_versions\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Retain X versions of the
+        repository. Default is null which retains all versions.\",\n                        \"minimum\":
+        1\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name for this repository.\"\n                    },\n                    \"manifest_signing_service\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"A reference to an associated signing service.\"\n                    },\n
+        \                   \"retain_checkpoints\": {\n                        \"type\":
         \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
         true,\n                        \"description\": \"Retain X checkpoint publications
         for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
-        1\n                    },\n                    \"retain_repo_versions\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Retain X versions of the repository. Default is null which retains all versions.\",\n
-        \                       \"minimum\": 1\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name for this repository.\"\n
-        \                   },\n                    \"description\": {\n                        \"type\":
+        1\n                    },\n                    \"description\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"An optional description.\"\n
-        \                   },\n                    \"manifest_signing_service\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A reference to an associated signing service.\"\n                    }\n
-        \               }\n            },\n            \"Patchedcontainer.ContainerRemote\":
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerRemote\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ContainerRemote.\",\n                \"properties\": {\n
         \                   \"name\": {\n                        \"type\": \"string\",\n
@@ -65854,7 +66056,7 @@ interactions:
         \               ]\n            },\n            \"Purge\": {\n                \"type\":
         \"object\",\n                \"properties\": {\n                    \"finished_before\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"default\": \"2026-03-28\",\n                        \"description\":
+        \"date-time\",\n                        \"default\": \"2026-04-25\",\n                        \"description\":
         \"Purge tasks completed earlier than this timestamp. Format '%Y-%m-%d[T%H:%M:%S]'\"\n
         \                   },\n                    \"states\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"$ref\":
@@ -65888,27 +66090,32 @@ interactions:
         \               ]\n            },\n            \"PythonPackageContentUpload\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for requests to synchronously upload Python packages.\",\n
-        \               \"properties\": {\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"file\":
+        \               \"properties\": {\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -66030,26 +66237,32 @@ interactions:
         [\n                    \"name\"\n                ]\n            },\n            \"RPMPackageUpload\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for requests to synchronously upload RPM packages.\",\n                \"properties\":
-        {\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        {\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -66296,7 +66509,12 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"description\": \"A repository version
         whose content will be used as the initial set of content for the new repository
-        version\"\n                    }\n                }\n            },\n            \"RepositoryResponse\":
+        version\"\n                    },\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"default\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Defaults
+        to true.\"\n                    }\n                }\n            },\n            \"RepositoryResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Base serializer for use with [pulpcore.app.models.Model][]\\n\\nThis ensures
         that all Serializers provide values for the 'pulp_href` field.\\n\\nThe class
@@ -66987,7 +67205,36 @@ interactions:
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to be used for
         authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"q_select\":
+        are not trimmed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"q_select\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"description\": \"Filter distributions on
         the upstream Pulp using complex filtering. E.g. pulp_label_select=\\\"foo\\\"
@@ -67034,7 +67281,36 @@ interactions:
         \"A PEM encoded client certificate used for authentication.\"\n                    },\n
         \                   \"tls_validation\": {\n                        \"type\":
         \"boolean\",\n                        \"description\": \"If True, TLS peer
-        validation must be performed.\"\n                    },\n                    \"hidden_fields\":
+        validation must be performed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"hidden_fields\":
         {\n                        \"type\": \"array\",\n                        \"items\":
         {\n                            \"type\": \"object\",\n                            \"properties\":
         {\n                                \"name\": {\n                                    \"type\":
@@ -67310,13 +67586,18 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"The name of the Collection.\"\n                    },\n                    \"namespace\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"The namespace of the Collection.\"\n
@@ -67361,6 +67642,12 @@ interactions:
         \                   \"content_guard\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
         true,\n                        \"description\": \"An optional content-guard.\"\n
+        \                   },\n                    \"hidden\": {\n                        \"type\":
+        \"boolean\",\n                        \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
         \                   },\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
@@ -67370,26 +67657,45 @@ interactions:
         \                   \"repository_version\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
         true,\n                        \"description\": \"RepositoryVersion to be
-        served\"\n                    },\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    }\n                },\n
-        \               \"required\": [\n                    \"base_path\",\n                    \"name\"\n
-        \               ]\n            },\n            \"ansible.AnsibleDistributionResponse\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"Serializer for Ansible Distributions.\",\n                \"properties\":
-        {\n                    \"pulp_href\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"pulp_created\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"base_path\": {\n                        \"type\":
-        \"string\",\n                        \"description\": \"The base (relative)
-        path component of the published url. Avoid paths that                     overlap
-        with other distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n
-        \                   },\n                    \"content_guard\": {\n                        \"type\":
+        served\"\n                    }\n                },\n                \"required\":
+        [\n                    \"base_path\",\n                    \"name\"\n                ]\n
+        \           },\n            \"ansible.AnsibleDistributionResponse\": {\n                \"type\":
+        \"object\",\n                \"description\": \"Serializer for Ansible Distributions.\",\n
+        \               \"properties\": {\n                    \"pulp_href\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"pulp_created\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of creation.\"\n                    },\n                    \"pulp_last_updated\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of the last time this resource was updated. Note: for immutable
+        resources - like content, repository versions, and publication - pulp_created
+        and pulp_last_updated dates will be the same.\"\n                    },\n
+        \                   \"base_path\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
+        \                   \"content_guard\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
         true,\n                        \"description\": \"An optional content-guard.\"\n
+        \                   },\n                    \"content_guard_prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN) of the associated optional content guard.\"\n
+        \                   },\n                    \"no_content_change_since\": {\n
+        \                       \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp since when the
+        distributed content served by this distribution has not changed. If equals
+        to `null`, no guarantee is provided about content changes.\"\n                    },\n
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
         \                   },\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"description\": \"A unique name. Ex,
         `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
@@ -67402,18 +67708,14 @@ interactions:
         served\"\n                    },\n                    \"client_url\": {\n
         \                       \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"The URL of a Collection
-        content source.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    }\n                },\n
-        \               \"required\": [\n                    \"base_path\",\n                    \"name\"\n
-        \               ]\n            },\n            \"ansible.AnsibleNamespaceMetadata\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A serializer for Namespaces.\",\n                \"properties\": {\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        3,\n                        \"description\": \"Required named, only accepts
-        lowercase, numbers and underscores.\",\n                        \"maxLength\":
-        64,\n                        \"pattern\": \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n
+        content source.\"\n                    }\n                },\n                \"required\":
+        [\n                    \"base_path\",\n                    \"name\"\n                ]\n
+        \           },\n            \"ansible.AnsibleNamespaceMetadata\": {\n                \"type\":
+        \"object\",\n                \"description\": \"A serializer for Namespaces.\",\n
+        \               \"properties\": {\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 3,\n                        \"description\":
+        \"Required named, only accepts lowercase, numbers and underscores.\",\n                        \"maxLength\":
+        64,\n                        \"pattern\": \"^(?!.*__)[a-z][0-9a-z_]*$\"\n
         \                   },\n                    \"company\": {\n                        \"type\":
         \"string\",\n                        \"description\": \"Optional namespace
         company owner.\",\n                        \"maxLength\": 64\n                    },\n
@@ -67442,7 +67744,7 @@ interactions:
         \                       \"description\": \"Required named, only accepts lowercase,
         numbers and underscores.\",\n                        \"maxLength\": 64,\n
         \                       \"minLength\": 3,\n                        \"pattern\":
-        \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n                    },\n                    \"company\":
+        \"^(?!.*__)[a-z][0-9a-z_]*$\"\n                    },\n                    \"company\":
         {\n                        \"type\": \"string\",\n                        \"description\":
         \"Optional namespace company owner.\",\n                        \"maxLength\":
         64\n                    },\n                    \"email\": {\n                        \"type\":
@@ -67763,21 +68065,19 @@ interactions:
         [\n                    \"name\",\n                    \"namespace\"\n                ]\n
         \           },\n            \"ansible.CollectionVersion\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for CollectionVersion
-        Content.\",\n                \"properties\": {\n                    \"artifact\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        Content.\",\n                \"properties\": {\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        be turned into the content unit.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
         \                   \"downloader_config\": {\n                        \"allOf\":
         [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
@@ -67788,10 +68088,18 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"file_url\": {\n                        \"type\":
-        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"expected_name\":
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"expected_name\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"The name of the collection.\",\n                        \"maxLength\": 64\n
@@ -67835,26 +68143,27 @@ interactions:
         \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"pulp_created\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of creation.\"\n                    },\n                    \"artifact\":
+        \"Timestamp of creation.\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"pulp_href\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"pulp_last_updated\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of the last time
+        this resource was updated. Note: for immutable resources - like content, repository
+        versions, and publication - pulp_created and pulp_last_updated dates will
+        be the same.\"\n                    },\n                    \"vuln_report\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"pulp_last_updated\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of the last time this resource was updated. Note: for immutable
-        resources - like content, repository versions, and publication - pulp_created
-        and pulp_last_updated dates will be the same.\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"vuln_report\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"sha256\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"sha256\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
         \"The SHA-256 checksum if available.\"\n                    },\n                    \"md5\":
         {\n                        \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"The MD5 checksum if available.\"\n
@@ -67928,13 +68237,19 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -67991,52 +68306,59 @@ interactions:
         [\n                    \"signed_collection\"\n                ]\n            },\n
         \           \"ansible.GitRemote\": {\n                \"type\": \"object\",\n
         \               \"description\": \"A serializer for Git Collection Remotes.\",\n
-        \               \"properties\": {\n                    \"sock_read_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"client_key\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        \               \"properties\": {\n                    \"client_key\": {\n
+        \                       \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"A PEM encoded private key used
-        for authentication.\"\n                    },\n                    \"proxy_password\":
+        for authentication.\"\n                    },\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"proxy_password\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to authenticate
         to the proxy. Extra leading and trailing whitespace characters are not trimmed.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"client_cert\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
-        \                   \"proxy_username\": {\n                        \"type\":
+        \                   },\n                    \"password\": {\n                        \"type\":
         \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"The username to authenticte to the proxy.\"\n                    },\n                    \"connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"The password to be used for authentication when syncing. Extra leading and
+        trailing whitespace characters are not trimmed.\"\n                    },\n
+        \                   \"ca_cert\": {\n                        \"type\": \"string\",\n
+        \                       \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A PEM encoded CA certificate
+        used to validate the server certificate presented by the remote server.\"\n
+        \                   },\n                    \"connect_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"sock_connect_timeout\": {\n
+        \                       \"type\": \"number\",\n                        \"format\":
         \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
         (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"tls_validation\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        default from the aiohttp library to be used.\"\n                    },\n                    \"url\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The URL of an external content
+        source.\"\n                    },\n                    \"username\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to be used for authentication when syncing.\"\n                    },\n
         \                   \"headers\": {\n                        \"type\": \"array\",\n
         \                       \"items\": {\n                            \"type\":
         \"object\"\n                        },\n                        \"description\":
-        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"password\":
+        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"client_cert\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"A unique name for this remote.\"\n                    },\n                    \"proxy_username\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The password to be used for
-        authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"total_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_url\":
+        1,\n                        \"description\": \"The username to authenticte
+        to the proxy.\"\n                    },\n                    \"proxy_url\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"download_concurrency\":
@@ -68044,87 +68366,73 @@ interactions:
         \"int64\",\n                        \"nullable\": true,\n                        \"description\":
         \"Total number of simultaneous connections. If not set then the default value
         will be used.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"ca_cert\": {\n                        \"type\": \"string\",\n
-        \                       \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded CA certificate
-        used to validate the server certificate presented by the remote server.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this remote.\"\n                    },\n                    \"url\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The URL of an external content
-        source.\"\n                    },\n                    \"max_retries\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Maximum number of retry attempts after a download failure. If not set then
-        the default value (3) will be used.\"\n                    },\n                    \"username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to be used for
-        authentication when syncing.\"\n                    },\n                    \"sock_connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"metadata_only\":
+        \                   \"rate_limit\": {\n                        \"type\": \"integer\",\n
+        \                       \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Limits requests per second
+        for each concurrent downloader\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"tls_validation\":
         {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, only metadata about the content will be stored in Pulp. Clients
-        will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"sock_read_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"total_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"metadata_only\": {\n                        \"type\":
+        \"boolean\",\n                        \"description\": \"If True, only metadata
+        about the content will be stored in Pulp. Clients will retrieve content from
+        the remote URL.\"\n                    },\n                    \"git_ref\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"A git ref. e.g.: branch, tag,
         or commit sha.\"\n                    }\n                },\n                \"required\":
         [\n                    \"name\",\n                    \"url\"\n                ]\n
         \           },\n            \"ansible.GitRemoteResponse\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for Git Collection
-        Remotes.\",\n                \"properties\": {\n                    \"prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
-        \                   },\n                    \"hidden_fields\": {\n                        \"type\":
-        \"array\",\n                        \"items\": {\n                            \"type\":
-        \"object\",\n                            \"properties\": {\n                                \"name\":
-        {\n                                    \"type\": \"string\"\n                                },\n
-        \                               \"is_set\": {\n                                    \"type\":
-        \"boolean\"\n                                }\n                            },\n
-        \                           \"required\": [\n                                \"is_set\",\n
-        \                               \"name\"\n                            ]\n
-        \                       },\n                        \"readOnly\": true,\n
-        \                       \"description\": \"List of hidden (write only) fields\"\n
-        \                   },\n                    \"sock_read_timeout\": {\n                        \"type\":
-        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
-        0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
-        is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"pulp_last_updated\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of the most recent update of the remote.\"\n                    },\n
-        \                   \"client_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
-        \                   \"connect_timeout\": {\n                        \"type\":
+        Remotes.\",\n                \"properties\": {\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"ca_cert\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"description\": \"A PEM encoded CA certificate
+        used to validate the server certificate presented by the remote server.\"\n
+        \                   },\n                    \"connect_timeout\": {\n                        \"type\":
         \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
         0.0,\n                        \"nullable\": true,\n                        \"description\":
         \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
         is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"tls_validation\": {\n                        \"type\":
-        \"boolean\",\n                        \"description\": \"If True, TLS peer
-        validation must be performed.\"\n                    },\n                    \"headers\":
-        {\n                        \"type\": \"array\",\n                        \"items\":
-        {\n                            \"type\": \"object\"\n                        },\n
-        \                       \"description\": \"Headers for aiohttp.Clientsession\"\n
-        \                   },\n                    \"pulp_href\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"total_timeout\": {\n                        \"type\":
-        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
-        0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
-        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"sock_connect_timeout\": {\n
+        \                       \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"pulp_href\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"url\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"The URL of an external content
+        source.\"\n                    },\n                    \"pulp_last_updated\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of the most recent update of the remote.\"\n                    },\n
+        \                   \"headers\": {\n                        \"type\": \"array\",\n
+        \                       \"items\": {\n                            \"type\":
+        \"object\"\n                        },\n                        \"description\":
+        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
+        \                   },\n                    \"client_cert\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"description\":
+        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"A unique name for this remote.\"\n
         \                   },\n                    \"proxy_url\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"description\":
         \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"download_concurrency\":
@@ -68135,63 +68443,78 @@ interactions:
         \                   \"pulp_created\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"ca_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A PEM encoded CA certificate used to validate the server certificate presented
-        by the remote server.\"\n                    },\n                    \"pulp_labels\":
+        \                   },\n                    \"rate_limit\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Limits requests per second
+        for each concurrent downloader\"\n                    },\n                    \"pulp_labels\":
         {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name for this remote.\"\n                    },\n                    \"url\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"The URL of an external content source.\"\n                    },\n                    \"max_retries\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Maximum number of retry attempts after a download failure. If not set then
-        the default value (3) will be used.\"\n                    },\n                    \"sock_connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"metadata_only\":
+        true\n                        }\n                    },\n                    \"tls_validation\":
         {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, only metadata about the content will be stored in Pulp. Clients
-        will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"sock_read_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"hidden_fields\": {\n                        \"type\":
+        \"array\",\n                        \"items\": {\n                            \"type\":
+        \"object\",\n                            \"properties\": {\n                                \"name\":
+        {\n                                    \"type\": \"string\"\n                                },\n
+        \                               \"is_set\": {\n                                    \"type\":
+        \"boolean\"\n                                }\n                            },\n
+        \                           \"required\": [\n                                \"is_set\",\n
+        \                               \"name\"\n                            ]\n
+        \                       },\n                        \"readOnly\": true,\n
+        \                       \"description\": \"List of hidden (write only) fields\"\n
+        \                   },\n                    \"total_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
+        is null, which will cause the default from the aiohttp library to be used.\"\n
+        \                   },\n                    \"metadata_only\": {\n                        \"type\":
+        \"boolean\",\n                        \"description\": \"If True, only metadata
+        about the content will be stored in Pulp. Clients will retrieve content from
+        the remote URL.\"\n                    },\n                    \"git_ref\":
         {\n                        \"type\": \"string\",\n                        \"description\":
         \"A git ref. e.g.: branch, tag, or commit sha.\"\n                    }\n
         \               },\n                \"required\": [\n                    \"name\",\n
         \                   \"url\"\n                ]\n            },\n            \"ansible.Role\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for Role versions.\",\n                \"properties\": {\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
+        \                   \"overwrite\": {\n                        \"type\": \"boolean\",\n
+        \                       \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"A URI of a repository the new content unit should be associated with.\"\n
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        },\n
         \                       \"description\": \"A dictionary of arbitrary key/value
         pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"repository\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"version\":
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"version\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1\n                    },\n                    \"name\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1\n                    },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1\n                    },\n
-        \                   \"namespace\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    }\n                },\n
-        \               \"required\": [\n                    \"artifact\",\n                    \"name\",\n
-        \                   \"namespace\",\n                    \"version\"\n                ]\n
-        \           },\n            \"ansible.RoleRemote\": {\n                \"type\":
-        \"object\",\n                \"description\": \"A serializer for Ansible Remotes.\",\n
-        \               \"properties\": {\n                    \"name\": {\n                        \"type\":
+        1\n                    },\n                    \"namespace\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    }\n
+        \               },\n                \"required\": [\n                    \"artifact\",\n
+        \                   \"name\",\n                    \"namespace\",\n                    \"version\"\n
+        \               ]\n            },\n            \"ansible.RoleRemote\": {\n
+        \               \"type\": \"object\",\n                \"description\": \"A
+        serializer for Ansible Remotes.\",\n                \"properties\": {\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"A unique name for this remote.\"\n
+        \                   },\n                    \"url\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this remote.\"\n                    },\n                    \"url\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The URL of an external content
-        source.\"\n                    },\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        \"The URL of an external content source.\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
         true\n                        }\n                    },\n                    \"policy\":
         {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
@@ -68364,7 +68687,14 @@ interactions:
         \                   },\n                    \"pulp_created\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"artifact\": {\n                        \"type\":
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"artifact\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
         \"Artifact file representing the physical content\"\n                    },\n
         \                   \"pulp_last_updated\": {\n                        \"type\":
@@ -68372,18 +68702,11 @@ interactions:
         true,\n                        \"description\": \"Timestamp of the last time
         this resource was updated. Note: for immutable resources - like content, repository
         versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"pulp_href\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
+        be the same.\"\n                    },\n                    \"vuln_report\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"vuln_report\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"version\": {\n                        \"type\":
-        \"string\"\n                    },\n                    \"name\": {\n                        \"type\":
+        \                   \"version\": {\n                        \"type\": \"string\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
         \"string\"\n                    },\n                    \"namespace\": {\n
         \                       \"type\": \"string\"\n                    }\n                },\n
         \               \"required\": [\n                    \"artifact\",\n                    \"name\",\n
@@ -68497,92 +68820,93 @@ interactions:
         [\n                    \"artifact\",\n                    \"digest\"\n                ]\n
         \           },\n            \"container.ContainerDistribution\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for ContainerDistribution.\",\n
-        \               \"properties\": {\n                    \"hidden\": {\n                        \"type\":
-        \"boolean\",\n                        \"default\": false,\n                        \"description\":
-        \"Whether this distribution should be shown in the content app.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
+        \               \"properties\": {\n                    \"base_path\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"private\": {\n                        \"type\": \"boolean\",\n
+        \                       \"description\": \"Restrict pull access to explicitly
+        authorized users. Defaults to unrestricted pull access.\"\n                    },\n
+        \                   \"description\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"An optional description.\"\n
+        \                   }\n                },\n                \"required\": [\n
+        \                   \"base_path\",\n                    \"name\"\n                ]\n
+        \           },\n            \"container.ContainerDistributionResponse\": {\n
+        \               \"type\": \"object\",\n                \"description\": \"A
+        serializer for ContainerDistribution.\",\n                \"properties\":
+        {\n                    \"no_content_change_since\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp since when the distributed content served by this distribution
+        has not changed. If equals to `null`, no guarantee is provided about content
+        changes.\"\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"base_path\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
         \"The base (relative) path component of the published url. Avoid paths that
         \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"content_guard_prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
+        of the associated optional content guard.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"private\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"Restrict pull access to explicitly authorized users. Defaults to unrestricted
-        pull access.\"\n                    },\n                    \"description\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"An optional description.\"\n                    }\n                },\n
-        \               \"required\": [\n                    \"base_path\",\n                    \"name\"\n
-        \               ]\n            },\n            \"container.ContainerDistributionResponse\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A serializer for ContainerDistribution.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"pulp_created\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of creation.\"\n                    },\n                    \"pulp_last_updated\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
+        \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"pulp_last_updated\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
         \"Timestamp of the last time this resource was updated. Note: for immutable
         resources - like content, repository versions, and publication - pulp_created
         and pulp_last_updated dates will be the same.\"\n                    },\n
-        \                   \"no_content_change_since\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"registry_path\": {\n                        \"type\":
         \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp since when the distributed content served by this distribution
-        has not changed. If equals to `null`, no guarantee is provided about content
-        changes.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"description\": \"A unique name. Ex,
-        `rawhide` and `stable`.\"\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"repository\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"The latest RepositoryVersion
-        for this Repository will be served.\"\n                    },\n                    \"base_path\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"registry_path\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Registry hostname/name/
-        to use with docker pull command defined by this distribution.\"\n                    },\n
-        \                   \"remote\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Remote that can be used
-        to fetch content when using pull-through caching.\"\n                    },\n
-        \                   \"namespace\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"readOnly\":
+        \"The Registry hostname/name/ to use with docker pull command defined by this
+        distribution.\"\n                    },\n                    \"remote\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Remote that can be used to fetch content when using pull-through caching.\"\n
+        \                   },\n                    \"namespace\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Namespace this distribution
         belongs to.\"\n                    },\n                    \"private\": {\n
         \                       \"type\": \"boolean\",\n                        \"description\":
@@ -68618,33 +68942,34 @@ interactions:
         \                   \"name\"\n                ]\n            },\n            \"container.ContainerPullThroughDistribution\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
-        \               \"properties\": {\n                    \"hidden\": {\n                        \"type\":
-        \"boolean\",\n                        \"default\": false,\n                        \"description\":
-        \"Whether this distribution should be shown in the content app.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"repository\":
+        \               \"properties\": {\n                    \"base_path\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"remote\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Remote that can be used
-        to fetch content when using pull-through caching.\"\n                    },\n
-        \                   \"distributions\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"remote\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Remote that can be used to fetch content when using pull-through caching.\"\n
+        \                   },\n                    \"distributions\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"type\":
         \"string\",\n                            \"format\": \"uri\"\n                        },\n
         \                       \"description\": \"Distributions created after pulling
@@ -68660,54 +68985,54 @@ interactions:
         \               ]\n            },\n            \"container.ContainerPullThroughDistributionResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
-        \               \"properties\": {\n                    \"prn\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"pulp_created\":
+        \               \"properties\": {\n                    \"no_content_change_since\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp since when the
+        distributed content served by this distribution has not changed. If equals
+        to `null`, no guarantee is provided about content changes.\"\n                    },\n
+        \                   \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"base_path\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"The base (relative) path component of the published url. Avoid paths that
+        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"content_guard_prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
+        of the associated optional content guard.\"\n                    },\n                    \"content_guard\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of creation.\"\n                    },\n                    \"pulp_last_updated\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
+        \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"pulp_last_updated\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
         \"Timestamp of the last time this resource was updated. Note: for immutable
         resources - like content, repository versions, and publication - pulp_created
         and pulp_last_updated dates will be the same.\"\n                    },\n
-        \                   \"no_content_change_since\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp since when the distributed content served by this distribution
-        has not changed. If equals to `null`, no guarantee is provided about content
-        changes.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"description\": \"A unique name. Ex,
-        `rawhide` and `stable`.\"\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"repository\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"The latest RepositoryVersion
-        for this Repository will be served.\"\n                    },\n                    \"base_path\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"remote\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Remote that can be used
-        to fetch content when using pull-through caching.\"\n                    },\n
-        \                   \"distributions\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"remote\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Remote that can be used to fetch content when using pull-through caching.\"\n
+        \                   },\n                    \"distributions\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"type\":
         \"string\",\n                            \"format\": \"uri\"\n                        },\n
         \                       \"description\": \"Distributions created after pulling
@@ -68923,74 +69248,73 @@ interactions:
         \               ]\n            },\n            \"container.ContainerPushRepository\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"retain_checkpoints\": {\n                        \"type\":
+        {\n                    \"retain_repo_versions\": {\n                        \"type\":
         \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Retain X checkpoint publications
-        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
-        1\n                    },\n                    \"retain_repo_versions\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Retain X versions of the repository. Default is null which retains all versions.\",\n
-        \                       \"minimum\": 1\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name for this repository.\"\n
-        \                   },\n                    \"description\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"An optional description.\"\n
-        \                   },\n                    \"manifest_signing_service\":
+        true,\n                        \"description\": \"Retain X versions of the
+        repository. Default is null which retains all versions.\",\n                        \"minimum\":
+        1\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name for this repository.\"\n                    },\n                    \"manifest_signing_service\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A reference to an associated signing service.\"\n                    }\n
-        \               },\n                \"required\": [\n                    \"name\"\n
-        \               ]\n            },\n            \"container.ContainerPushRepositoryResponse\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"retain_checkpoints\": {\n                        \"type\":
+        \"A reference to an associated signing service.\"\n                    },\n
+        \                   \"retain_checkpoints\": {\n                        \"type\":
         \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
         true,\n                        \"description\": \"Retain X checkpoint publications
         for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
-        1\n                    },\n                    \"prn\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        1\n                    },\n                    \"description\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"An optional description.\"\n
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   }\n                },\n                \"required\": [\n
+        \                   \"name\"\n                ]\n            },\n            \"container.ContainerPushRepositoryResponse\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"Serializer for Container Push Repositories.\",\n                \"properties\":
+        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
         \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"retain_repo_versions\":
         {\n                        \"type\": \"integer\",\n                        \"format\":
         \"int64\",\n                        \"nullable\": true,\n                        \"description\":
         \"Retain X versions of the repository. Default is null which retains all versions.\",\n
-        \                       \"minimum\": 1\n                    },\n                    \"pulp_created\":
+        \                       \"minimum\": 1\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"A unique name for this repository.\"\n                    },\n                    \"manifest_signing_service\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of creation.\"\n                    },\n                    \"pulp_last_updated\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of the last time this resource was updated. Note: for immutable
-        resources - like content, repository versions, and publication - pulp_created
-        and pulp_last_updated dates will be the same.\"\n                    },\n
-        \                   \"versions_href\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"description\": \"A unique name for
-        this repository.\"\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"A reference to an associated signing service.\"\n                    },\n
+        \                   \"retain_checkpoints\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Retain X checkpoint publications
+        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
+        1\n                    },\n                    \"latest_version_href\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
         \                   \"description\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"An optional description.\"\n                    },\n                    \"latest_version_href\":
+        \"An optional description.\"\n                    },\n                    \"pulp_created\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of creation.\"\n                    },\n                    \"versions_href\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"manifest_signing_service\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"A reference to an associated
-        signing service.\"\n                    }\n                },\n                \"required\":
-        [\n                    \"name\"\n                ]\n            },\n            \"container.ContainerRemote\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A Serializer for ContainerRemote.\",\n                \"properties\": {\n
-        \                   \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"pulp_last_updated\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of the last time this resource was updated. Note: for immutable
+        resources - like content, repository versions, and publication - pulp_created
+        and pulp_last_updated dates will be the same.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"name\"\n                ]\n
+        \           },\n            \"container.ContainerRemote\": {\n                \"type\":
+        \"object\",\n                \"description\": \"A Serializer for ContainerRemote.\",\n
+        \               \"properties\": {\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"A unique name for this remote.\"\n                    },\n                    \"url\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"The URL of an external content
@@ -69999,30 +70323,35 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70081,16 +70410,22 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
-        \                       \"description\": \"A dict mapping relative paths inside
-        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
-        \                   },\n                    \"component\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifacts\": {\n
+        \                       \"type\": \"object\",\n                        \"description\":
+        \"A dict mapping relative paths inside the Content to the correspondingArtifact
+        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
+        \                   \"component\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
         \"Component of the component - architecture combination.\"\n                    },\n
         \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
@@ -70142,30 +70477,35 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70272,29 +70612,35 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70310,17 +70656,22 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifacts\": {\n
-        \                       \"type\": \"object\",\n                        \"description\":
-        \"A dict mapping relative paths inside the Content to the correspondingArtifact
-        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
-        \                   \"component\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
+        \                       \"description\": \"A dict mapping relative paths inside
+        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
+        \                   },\n                    \"component\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Component of the component - architecture combination.\"\n                    },\n
         \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
@@ -70370,26 +70721,31 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"package\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Package that is contained in release_comonent.\"\n                    },\n
-        \                   \"release_component\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"ReleaseComponent this package is contained in.\"\n                    }\n
-        \               },\n                \"required\": [\n                    \"package\",\n
-        \                   \"release_component\"\n                ]\n            },\n
-        \           \"deb.PackageReleaseComponentResponse\": {\n                \"type\":
-        \"object\",\n                \"description\": \"A Serializer for PackageReleaseComponent.\",\n
-        \               \"properties\": {\n                    \"pulp_href\": {\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"package\": {\n
         \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
+        \"uri\",\n                        \"description\": \"Package that is contained
+        in release_comonent.\"\n                    },\n                    \"release_component\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"ReleaseComponent this
+        package is contained in.\"\n                    }\n                },\n                \"required\":
+        [\n                    \"package\",\n                    \"release_component\"\n
+        \               ]\n            },\n            \"deb.PackageReleaseComponentResponse\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"A Serializer for PackageReleaseComponent.\",\n                \"properties\":
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
         \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"pulp_created\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
@@ -70519,15 +70875,21 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"codename\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    },\n                    \"suite\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1\n                    },\n                    \"distribution\": {\n                        \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"codename\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1\n                    },\n                    \"suite\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    },\n
+        \                   \"distribution\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1\n                    },\n
         \                   \"version\": {\n                        \"type\": \"string\",\n
         \                       \"nullable\": true,\n                        \"minLength\":
@@ -70551,18 +70913,24 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"architecture\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Name of the architecture.\"\n
-        \                   },\n                    \"distribution\": {\n                        \"type\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Name of the distribution.\"\n                    }\n                },\n
-        \               \"required\": [\n                    \"architecture\",\n                    \"distribution\"\n
+        \"Name of the architecture.\"\n                    },\n                    \"distribution\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Name of the distribution.\"\n
+        \                   }\n                },\n                \"required\": [\n
+        \                   \"architecture\",\n                    \"distribution\"\n
         \               ]\n            },\n            \"deb.ReleaseArchitectureResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ReleaseArchitecture.\",\n                \"properties\":
@@ -70598,18 +70966,23 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"component\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"Name of the component.\"\n                    },\n                    \"distribution\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Name of the distribution.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"component\",\n                    \"distribution\"\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"component\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Name of the component.\"\n
+        \                   },\n                    \"distribution\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Name of the distribution.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"component\",\n                    \"distribution\"\n
         \               ]\n            },\n            \"deb.ReleaseComponentResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ReleaseComponent.\",\n                \"properties\": {\n
@@ -70647,17 +71020,22 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifacts\": {\n
-        \                       \"type\": \"object\",\n                        \"description\":
-        \"A dict mapping relative paths inside the Content to the correspondingArtifact
-        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
-        \                   \"codename\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
+        \                       \"description\": \"A dict mapping relative paths inside
+        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
+        \                   },\n                    \"codename\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Codename of the release, e.g. \\\"buster\\\".\"\n                    },\n
         \                   \"suite\": {\n                        \"type\": \"string\",\n
         \                       \"minLength\": 1,\n                        \"description\":
@@ -70753,16 +71131,22 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
-        \                       \"description\": \"A dict mapping relative paths inside
-        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
-        \                   },\n                    \"release\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifacts\": {\n
+        \                       \"type\": \"object\",\n                        \"description\":
+        \"A dict mapping relative paths inside the Content to the correspondingArtifact
+        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
+        \                   \"release\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
         \"Release this index file belongs to.\"\n                    },\n                    \"component\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Component this index file belongs
@@ -70812,27 +71196,38 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"Artifact URL of the Debian
-        Source Control (dsc) file.\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Relative path of the Debian
-        Source Control (dsc) file.It is normally advised to let Pulp generate this.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"artifact\"\n                ]\n            },\n            \"deb.SourcePackageReleaseComponent\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A Serializer for SourcePackageReleaseComponent.\",\n                \"properties\":
-        {\n                    \"repository\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"Artifact URL of the Debian Source Control (dsc) file.\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Relative path of the Debian Source Control (dsc) file.It is normally advised
+        to let Pulp generate this.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"artifact\"\n                ]\n
+        \           },\n            \"deb.SourcePackageReleaseComponent\": {\n                \"type\":
+        \"object\",\n                \"description\": \"A Serializer for SourcePackageReleaseComponent.\",\n
+        \               \"properties\": {\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"A URI of a repository the new content unit should be associated with.\"\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
         true\n                        },\n                        \"description\":
         \"A dictionary of arbitrary key/value pairs used to describe a specific Content
@@ -71039,29 +71434,35 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -71689,19 +72090,25 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"file\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that should be turned into the artifact of the content
-        unit.\"\n                    }\n                }\n            },\n            \"gem.GemContentResponse\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that should
+        be turned into the artifact of the content unit.\"\n                    }\n
+        \               }\n            },\n            \"gem.GemContentResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for GemContent.\",\n                \"properties\": {\n                    \"pulp_href\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -72148,19 +72555,24 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"The relative path within the repository\"\n                    },\n                    \"repo_id\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The relative path within the
-        repository\"\n                    },\n                    \"repo_id\": {\n
-        \                       \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"The Hugging Face repository
         ID (e.g., 'microsoft/DialoGPT-medium')\"\n                    },\n                    \"repo_type\":
         {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
@@ -72642,20 +73054,25 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"artifact\",\n                    \"relative_path\"\n
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"artifact\",\n                    \"relative_path\"\n
         \               ]\n            },\n            \"maven.MavenArtifactResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for MavenArtifact.\",\n                \"properties\": {\n
@@ -73388,30 +73805,36 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path.
-        If not provided, it will be computed from name and version.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path. If not provided, it will be computed
+        from name and version.\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -73530,21 +73953,26 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1\n                    },\n
-        \                   \"digest\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    }\n                },\n
-        \               \"required\": [\n                    \"artifact\",\n                    \"digest\",\n
-        \                   \"relative_path\"\n                ]\n            },\n
-        \           \"ostree.OstreeContentResponse\": {\n                \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1\n                    },\n                    \"digest\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    }\n
+        \               },\n                \"required\": [\n                    \"artifact\",\n
+        \                   \"digest\",\n                    \"relative_path\"\n                ]\n
+        \           },\n            \"ostree.OstreeContentResponse\": {\n                \"type\":
         \"object\",\n                \"description\": \"A Serializer class for uncategorized
         content units (e.g., static deltas).\",\n                \"properties\": {\n
         \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
@@ -74047,13 +74475,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -74258,30 +74691,36 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -74926,13 +75365,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Modulemd name.\"\n                    },\n                    \"stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Stream name.\"\n                    },\n
@@ -74972,13 +75416,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"module\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"module\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Modulemd name.\"\n                    },\n                    \"stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Modulemd default stream.\"\n
@@ -75025,34 +75474,39 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"modified\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"Obsolete modified time.\"\n                    },\n                    \"module_name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Modulemd name.\"\n                    },\n
-        \                   \"module_stream\": {\n                        \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"modified\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Obsolete modified time.\"\n
+        \                   },\n                    \"module_name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Modulemd's stream.\"\n                    },\n                    \"message\":
+        \"Modulemd name.\"\n                    },\n                    \"module_stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Obsolete description.\"\n                    },\n
-        \                   \"override_previous\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Reset previous obsoletes.\"\n
-        \                   },\n                    \"module_context\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Modulemd's context.\"\n                    },\n
-        \                   \"eol_date\": {\n                        \"type\": \"string\",\n
-        \                       \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"End of Life date.\"\n                    },\n
-        \                   \"obsoleted_by_module_name\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Obsolete by module name.\"\n
-        \                   },\n                    \"obsoleted_by_module_stream\":
+        1,\n                        \"description\": \"Modulemd's stream.\"\n                    },\n
+        \                   \"message\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"Obsolete description.\"\n                    },\n                    \"override_previous\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Reset previous obsoletes.\"\n                    },\n                    \"module_context\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Modulemd's context.\"\n                    },\n                    \"eol_date\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"End of Life date.\"\n                    },\n                    \"obsoleted_by_module_name\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Obsolete by module name.\"\n                    },\n                    \"obsoleted_by_module_stream\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"Obsolete by module stream.\"\n                    },\n                    \"snippet\":
@@ -75172,30 +75626,36 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -76444,13 +76904,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -76549,7 +77014,7 @@ interactions:
       Access-Control-Expose-Headers:
       - Correlation-ID
       Age:
-      - '4'
+      - '1'
       Allow:
       - GET, HEAD, OPTIONS
       Cache-Control:
@@ -76559,17 +77024,17 @@ interactions:
       Content-Disposition:
       - inline; filename="Pulp 3 API.json"
       Content-Length:
-      - '6373698'
+      - '6411073'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 9109b62e295a45f6a04c9daea2091a2c
+      - 6a01bb246f4e4869825acb433fb8534a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:34 GMT
+      - Mon, 25 May 2026 19:18:06 GMT
       Expires:
-      - Wed, 05 Aug 2026 15:05:30 GMT
+      - Wed, 02 Sep 2026 19:18:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -76597,13 +77062,13 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 9109b62e295a45f6a04c9daea2091a2c
+      - 6a01bb246f4e4869825acb433fb8534a
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
@@ -76621,11 +77086,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 9109b62e295a45f6a04c9daea2091a2c
+      - 6a01bb246f4e4869825acb433fb8534a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:35 GMT
+      - Mon, 25 May 2026 19:18:06 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -76655,20 +77120,20 @@ interactions:
       Content-Length:
       - '53'
       Correlation-Id:
-      - 9109b62e295a45f6a04c9daea2091a2c
+      - 6a01bb246f4e4869825acb433fb8534a
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: POST
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:36.208164Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:06.627467Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -76681,13 +77146,13 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 9109b62e295a45f6a04c9daea2091a2c
+      - 6a01bb246f4e4869825acb433fb8534a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:36 GMT
+      - Mon, 25 May 2026 19:18:06 GMT
       Location:
-      - /pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+      - /pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-1.yml
+++ b/tests/fixtures/file_repository-1.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:36.208164Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:06.627467Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 466428ba54bc4966aaec5dd1ab68d02d
+      - 1ba0e82e49c84c46a7e8ac9265666ecc
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:39 GMT
+      - Mon, 25 May 2026 19:18:07 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-10.yml
+++ b/tests/fixtures/file_repository-10.yml
@@ -17,12 +17,13 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:59.347748Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +32,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '695'
+      - '739'
       Content-Type:
       - application/json
       Correlation-ID:
-      - f0e98a88f4c84914b315a347bcd0e7af
+      - 6f07fccefcf34672add1335166d0dac1
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:02 GMT
+      - Mon, 25 May 2026 19:18:13 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-11.yml
+++ b/tests/fixtures/file_repository-11.yml
@@ -17,12 +17,13 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:59.347748Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +32,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '695'
+      - '739'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:04 GMT
+      - Mon, 25 May 2026 19:18:13 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -54,7 +55,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"autopublish": false}'
+    body: '{"description": null}'
     headers:
       ? !!python/object/new:multidict._multidict_py.istr
         args:
@@ -67,22 +68,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '22'
+      - '21'
       Correlation-Id:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019dcf79-e205-7a58-8c43-1d5e2eca9271/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-cbad-7920-ab34-5d7b54636ced/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -95,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:04 GMT
+      - Mon, 25 May 2026 19:18:13 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -127,18 +128,18 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019dcf79-e205-7a58-8c43-1d5e2eca9271/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-cbad-7920-ab34-5d7b54636ced/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019dcf79-e205-7a58-8c43-1d5e2eca9271/","prn":"prn:core.task:019dcf79-e205-7a58-8c43-1d5e2eca9271","pulp_created":"2026-04-27T15:06:04.681218Z","pulp_last_updated":"2026-04-27T15:06:04.677882Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"0caf977ab0c2489c88d5190d5759fd63","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-04-27T15:06:04.701344Z","started_at":"2026-04-27T15:06:04.710384Z","finished_at":"2026-04-27T15:06:04.745146Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","shared:prn:core.domain:34336c95-92ee-446b-adae-1152e7ac1ddd"],"result":{"prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","autopublish":false,"description":null,"pulp_labels":{},"pulp_created":"2026-04-27T15:05:36.186130Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_last_updated":"2026-04-27T15:06:04.724624Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","retain_repo_versions":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-cbad-7920-ab34-5d7b54636ced/","prn":"prn:core.task:019e6092-cbad-7920-ab34-5d7b54636ced","pulp_created":"2026-05-25T19:18:13.679320Z","pulp_last_updated":"2026-05-25T19:18:13.677413Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"76bbea0e44ff4bab85d7630486f0346b","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:13.686060Z","started_at":"2026-05-25T19:18:13.689422Z","finished_at":"2026-05-25T19:18:13.697101Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":{"prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","autopublish":true,"description":null,"pulp_labels":{"test_label":"1"},"pulp_created":"2026-05-25T19:18:06.621748Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_last_updated":"2026-05-25T19:18:13.693901Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","retain_repo_versions":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -147,15 +148,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1475'
+      - '1490'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:05 GMT
+      - Mon, 25 May 2026 19:18:13 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -183,18 +184,18 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:06:04.724624Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:13.693901Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -203,15 +204,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '644'
+      - '659'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 0caf977ab0c2489c88d5190d5759fd63
+      - 76bbea0e44ff4bab85d7630486f0346b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:05 GMT
+      - Mon, 25 May 2026 19:18:13 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-12.yml
+++ b/tests/fixtures/file_repository-12.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:06:04.724624Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:13.693901Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +31,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '696'
+      - '711'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 74981bc5f1b042809e255c2f12d6c2fb
+      - f262336c29c841ccb45bbd3de75a30fc
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:07 GMT
+      - Mon, 25 May 2026 19:18:14 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-13.yml
+++ b/tests/fixtures/file_repository-13.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:06:04.724624Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:13.693901Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +31,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '696'
+      - '711'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 646c99485e224d39b3402eac8ffaebd2
+      - 56d808e54fa848e8b5885816b92af852
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:09 GMT
+      - Mon, 25 May 2026 19:18:14 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -54,7 +54,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
+    body: '{"autopublish": false}'
     headers:
       ? !!python/object/new:multidict._multidict_py.istr
         args:
@@ -67,20 +67,22 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '0'
+      - '22'
       Correlation-Id:
-      - 646c99485e224d39b3402eac8ffaebd2
+      - 56d808e54fa848e8b5885816b92af852
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
-    method: DELETE
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+      : - Squeezer/0.4.0-dev
+      content-type:
+      - application/json
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019dcf79-f699-7ff6-8472-a8e82afdd37e/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-d0eb-7ae3-be12-08ce2d166e85/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -93,11 +95,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 646c99485e224d39b3402eac8ffaebd2
+      - 56d808e54fa848e8b5885816b92af852
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:10 GMT
+      - Mon, 25 May 2026 19:18:15 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -125,18 +127,18 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 646c99485e224d39b3402eac8ffaebd2
+      - 56d808e54fa848e8b5885816b92af852
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019dcf79-f699-7ff6-8472-a8e82afdd37e/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-d0eb-7ae3-be12-08ce2d166e85/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019dcf79-f699-7ff6-8472-a8e82afdd37e/","prn":"prn:core.task:019dcf79-f699-7ff6-8472-a8e82afdd37e","pulp_created":"2026-04-27T15:06:09.951939Z","pulp_last_updated":"2026-04-27T15:06:09.945982Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_delete","logging_cid":"646c99485e224d39b3402eac8ffaebd2","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-04-27T15:06:10.030852Z","started_at":"2026-04-27T15:06:10.138960Z","finished_at":"2026-04-27T15:06:10.381070Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","shared:prn:core.domain:34336c95-92ee-446b-adae-1152e7ac1ddd"],"result":null}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-d0eb-7ae3-be12-08ce2d166e85/","prn":"prn:core.task:019e6092-d0eb-7ae3-be12-08ce2d166e85","pulp_created":"2026-05-25T19:18:15.022370Z","pulp_last_updated":"2026-05-25T19:18:15.020271Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"56d808e54fa848e8b5885816b92af852","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:15.029599Z","started_at":"2026-05-25T19:18:15.033068Z","finished_at":"2026-05-25T19:18:15.040385Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":{"prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","autopublish":false,"description":null,"pulp_labels":{"test_label":"1"},"pulp_created":"2026-05-25T19:18:06.621748Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_last_updated":"2026-05-25T19:18:15.037062Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","retain_repo_versions":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -145,15 +147,71 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '835'
+      - '1491'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 646c99485e224d39b3402eac8ffaebd2
+      - 56d808e54fa848e8b5885816b92af852
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:10 GMT
+      - Mon, 25 May 2026 19:18:15 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Correlation-Id:
+      - 56d808e54fa848e8b5885816b92af852
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
+      : - Squeezer/0.4.0-dev
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:15.037062Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '660'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - 56d808e54fa848e8b5885816b92af852
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 25 May 2026 19:18:15 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-14.yml
+++ b/tests/fixtures/file_repository-14.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:15.037062Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +31,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '52'
+      - '712'
       Content-Type:
       - application/json
       Correlation-ID:
-      - b8d348d60eda4d0ca1c8e71c0d4275f1
+      - 26868b0318cf481db70f7a75d11cf9f2
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:06:12 GMT
+      - Mon, 25 May 2026 19:18:15 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-15.yml
+++ b/tests/fixtures/file_repository-15.yml
@@ -19,10 +19,10 @@ interactions:
           __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:05.769492Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:15.037062Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -31,15 +31,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1034'
+      - '712'
       Content-Type:
       - application/json
       Correlation-ID:
-      - a90608291534460ca5ab0a1d4c895420
+      - ef215072cf384604b902309278e97b25
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 18 May 2026 18:54:06 GMT
+      - Mon, 25 May 2026 19:18:16 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -69,7 +69,7 @@ interactions:
       Content-Length:
       - '0'
       Correlation-Id:
-      - a90608291534460ca5ab0a1d4c895420
+      - ef215072cf384604b902309278e97b25
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
@@ -77,10 +77,10 @@ interactions:
           __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: DELETE
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e3c70-34fa-7661-9b14-a89b24ce1d86/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-d626-745e-8b4f-1b41e845b830/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -93,11 +93,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - a90608291534460ca5ab0a1d4c895420
+      - ef215072cf384604b902309278e97b25
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 18 May 2026 18:54:07 GMT
+      - Mon, 25 May 2026 19:18:16 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -125,7 +125,7 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - a90608291534460ca5ab0a1d4c895420
+      - ef215072cf384604b902309278e97b25
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
@@ -133,10 +133,10 @@ interactions:
           __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-34fa-7661-9b14-a89b24ce1d86/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-d626-745e-8b4f-1b41e845b830/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-34fa-7661-9b14-a89b24ce1d86/","prn":"prn:core.task:019e3c70-34fa-7661-9b14-a89b24ce1d86","pulp_created":"2026-05-18T18:54:07.100443Z","pulp_last_updated":"2026-05-18T18:54:07.099128Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_delete","logging_cid":"a90608291534460ca5ab0a1d4c895420","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:54:07.108081Z","started_at":"2026-05-18T18:54:07.134194Z","finished_at":"2026-05-18T18:54:07.166387Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":null}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-d626-745e-8b4f-1b41e845b830/","prn":"prn:core.task:019e6092-d626-745e-8b4f-1b41e845b830","pulp_created":"2026-05-25T19:18:16.363492Z","pulp_last_updated":"2026-05-25T19:18:16.359517Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_delete","logging_cid":"ef215072cf384604b902309278e97b25","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:16.373417Z","started_at":"2026-05-25T19:18:16.403229Z","finished_at":"2026-05-25T19:18:16.436709Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -145,15 +145,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '833'
+      - '835'
       Content-Type:
       - application/json
       Correlation-ID:
-      - a90608291534460ca5ab0a1d4c895420
+      - ef215072cf384604b902309278e97b25
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 18 May 2026 18:54:07 GMT
+      - Mon, 25 May 2026 19:18:16 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-16.yml
+++ b/tests/fixtures/file_repository-16.yml
@@ -22,8 +22,7 @@ interactions:
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:09.579834Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -32,15 +31,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '723'
+      - '52'
       Content-Type:
       - application/json
       Correlation-ID:
-      - d62230281d0a46c4a0121392b1d8b08d
+      - f92b4602438c43afa89176cc3e203d33
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 25 May 2026 19:18:10 GMT
+      - Mon, 25 May 2026 19:18:16 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-2.yml
+++ b/tests/fixtures/file_repository-2.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:36.208164Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:06.627467Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -35,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:41 GMT
+      - Mon, 25 May 2026 19:18:08 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -69,20 +69,20 @@ interactions:
       Content-Length:
       - '49'
       Correlation-Id:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019dcf79-8a19-7fde-a953-06f50338b95d/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-b658-7046-a0c1-9b605802c3db/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -95,11 +95,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:42 GMT
+      - Mon, 25 May 2026 19:18:08 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -127,19 +127,19 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019dcf79-8a19-7fde-a953-06f50338b95d/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-b658-7046-a0c1-9b605802c3db/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019dcf79-8a19-7fde-a953-06f50338b95d/","prn":"prn:core.task:019dcf79-8a19-7fde-a953-06f50338b95d","pulp_created":"2026-04-27T15:05:42.180322Z","pulp_last_updated":"2026-04-27T15:05:42.171368Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"7080fad66f06478997c012904dd9b8e3","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-04-27T15:05:42.240546Z","started_at":"2026-04-27T15:05:42.264043Z","finished_at":"2026-04-27T15:05:42.311862Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","shared:prn:core.domain:34336c95-92ee-446b-adae-1152e7ac1ddd"],"result":{"prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","autopublish":false,"description":"repository
-        created via ansible","pulp_labels":{},"pulp_created":"2026-04-27T15:05:36.186130Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_last_updated":"2026-04-27T15:05:42.290628Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","retain_repo_versions":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-b658-7046-a0c1-9b605802c3db/","prn":"prn:core.task:019e6092-b658-7046-a0c1-9b605802c3db","pulp_created":"2026-05-25T19:18:08.220265Z","pulp_last_updated":"2026-05-25T19:18:08.217208Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"0067c24c4fc549b1aaab4a28f345a710","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:08.228208Z","started_at":"2026-05-25T19:18:08.232659Z","finished_at":"2026-05-25T19:18:08.240630Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":{"prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","autopublish":false,"description":"repository
+        created via ansible","pulp_labels":{},"pulp_created":"2026-05-25T19:18:06.621748Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_last_updated":"2026-05-25T19:18:08.237384Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","retain_repo_versions":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -152,11 +152,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:42 GMT
+      - Mon, 25 May 2026 19:18:08 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -184,18 +184,18 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:42.290628Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:08.237384Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}'
     headers:
       Access-Control-Expose-Headers:
@@ -209,11 +209,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7080fad66f06478997c012904dd9b8e3
+      - 0067c24c4fc549b1aaab4a28f345a710
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:43 GMT
+      - Mon, 25 May 2026 19:18:08 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-3.yml
+++ b/tests/fixtures/file_repository-3.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:42.290628Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:08.237384Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -36,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d64fb8536daa46b391727420068b57a8
+      - df46b0d2ddd24ecb8e90ffea72024d72
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:45 GMT
+      - Mon, 25 May 2026 19:18:08 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-4.yml
+++ b/tests/fixtures/file_repository-4.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:42.290628Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:08.237384Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":false,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -36,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:47 GMT
+      - Mon, 25 May 2026 19:18:09 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -70,20 +70,20 @@ interactions:
       Content-Length:
       - '21'
       Correlation-Id:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019dcf79-a10d-7494-8471-7773708ed391/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-bb9b-737f-9fa1-5cabcbe7cb16/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -96,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:48 GMT
+      - Mon, 25 May 2026 19:18:09 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -128,19 +128,19 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019dcf79-a10d-7494-8471-7773708ed391/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-bb9b-737f-9fa1-5cabcbe7cb16/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019dcf79-a10d-7494-8471-7773708ed391/","prn":"prn:core.task:019dcf79-a10d-7494-8471-7773708ed391","pulp_created":"2026-04-27T15:05:48.059575Z","pulp_last_updated":"2026-04-27T15:05:48.046817Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"53a8a0da9a0a4bbb94c14ef2e0cf6ad0","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-04-27T15:05:48.104778Z","started_at":"2026-04-27T15:05:48.122355Z","finished_at":"2026-04-27T15:05:48.172017Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","shared:prn:core.domain:34336c95-92ee-446b-adae-1152e7ac1ddd"],"result":{"prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"pulp_created":"2026-04-27T15:05:36.186130Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_last_updated":"2026-04-27T15:05:48.149578Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","retain_repo_versions":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-bb9b-737f-9fa1-5cabcbe7cb16/","prn":"prn:core.task:019e6092-bb9b-737f-9fa1-5cabcbe7cb16","pulp_created":"2026-05-25T19:18:09.565471Z","pulp_last_updated":"2026-05-25T19:18:09.563635Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"793cbcb00bfd43b3a9dd0e97f29b1ab6","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:09.572361Z","started_at":"2026-05-25T19:18:09.575738Z","finished_at":"2026-05-25T19:18:09.582655Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":{"prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"pulp_created":"2026-05-25T19:18:06.621748Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_last_updated":"2026-05-25T19:18:09.579834Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","retain_repo_versions":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -153,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:48 GMT
+      - Mon, 25 May 2026 19:18:09 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -185,18 +185,18 @@ interactions:
       Connection:
       - keep-alive
       Correlation-Id:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       ? !!python/object/new:multidict._multidict_py.istr
         args:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:48.149578Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:09.579834Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}'
     headers:
       Access-Control-Expose-Headers:
@@ -210,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 53a8a0da9a0a4bbb94c14ef2e0cf6ad0
+      - 793cbcb00bfd43b3a9dd0e97f29b1ab6
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:49 GMT
+      - Mon, 25 May 2026 19:18:09 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-6.yml
+++ b/tests/fixtures/file_repository-6.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:48.149578Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:09.579834Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -36,11 +36,185 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - c41a21c17bee42e6aa79ed8b24500a03
+      - fc2207e5dfec42a1a92bd55800f8ab06
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:52 GMT
+      - Mon, 25 May 2026 19:18:10 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"pulp_labels": {"test_label": "1"}}'
+    headers:
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Correlation-Id:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
+      : - Squeezer/0.4.0-dev
+      content-type:
+      - application/json
+    method: PATCH
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
+  response:
+    body:
+      string: '{"task":"/pulp/api/v3/tasks/019e6092-c0ca-774e-8d4b-9a8d3a2f43cc/"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 25 May 2026 19:18:10 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Correlation-Id:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
+      : - Squeezer/0.4.0-dev
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e6092-c0ca-774e-8d4b-9a8d3a2f43cc/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e6092-c0ca-774e-8d4b-9a8d3a2f43cc/","prn":"prn:core.task:019e6092-c0ca-774e-8d4b-9a8d3a2f43cc","pulp_created":"2026-05-25T19:18:10.894436Z","pulp_last_updated":"2026-05-25T19:18:10.890815Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"fc2207e5dfec42a1a92bd55800f8ab06","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-25T19:18:10.902527Z","started_at":"2026-05-25T19:18:10.907071Z","finished_at":"2026-05-25T19:18:10.915967Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","shared:prn:core.domain:174af0ec-9de3-42c4-a419-2414acba26a6"],"result":{"prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{"test_label":"1"},"pulp_created":"2026-05-25T19:18:06.621748Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_last_updated":"2026-05-25T19:18:10.912445Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","retain_repo_versions":null}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1518'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 25 May 2026 19:18:11 GMT
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - nginx/1.22.1
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Correlation-Id:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
+      : - Squeezer/0.4.0-dev
+    method: GET
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/
+  response:
+    body:
+      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}'
+    headers:
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json
+      Correlation-ID:
+      - fc2207e5dfec42a1a92bd55800f8ab06
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Mon, 25 May 2026 19:18:11 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-7.yml
+++ b/tests/fixtures/file_repository-7.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?offset=0&limit=1000
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:48.149578Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -32,15 +32,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '723'
+      - '739'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 2899fa52d95340c2b5ad50208e4ab4ec
+      - dceaecc1384e4d638d2767bf02139dbc
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:54 GMT
+      - Mon, 25 May 2026 19:18:11 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-8.yml
+++ b/tests/fixtures/file_repository-8.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:48.149578Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -32,15 +32,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '723'
+      - '739'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 5956afd1a0834c28bc35171b8f5a9b41
+      - 9591241f14ed4a2cb6d4d5366837b94f
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:56 GMT
+      - Mon, 25 May 2026 19:18:12 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/file_repository-9.yml
+++ b/tests/fixtures/file_repository-9.yml
@@ -17,12 +17,12 @@ interactions:
         - User-Agent
         state:
           __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
+      : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?name=test_file_repository&offset=0&limit=1
+    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/?offset=0&limit=1000
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:48.149578Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":"repository
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/","prn":"prn:file.filerepository:019e6092-b01c-7ced-b14a-63a48112652b","pulp_created":"2026-05-25T19:18:06.621748Z","pulp_last_updated":"2026-05-25T19:18:10.912445Z","versions_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/file/file/019e6092-b01c-7ced-b14a-63a48112652b/versions/0/","name":"test_file_repository","description":"repository
         created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}]}'
     headers:
       Access-Control-Expose-Headers:
@@ -32,187 +32,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '723'
+      - '739'
       Content-Type:
       - application/json
       Correlation-ID:
-      - 178dc40fce874d91bb34278d2c4d6996
+      - 433f6f1e7ef94b799c0a632211d40b4c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Mon, 27 Apr 2026 15:05:58 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"description": null}'
-    headers:
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - Accept
-        state:
-          __istr_identity__: Accept
-      : - application/json
-      Accept-Encoding:
-      - gzip, deflate, zstd
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '21'
-      Correlation-Id:
-      - 178dc40fce874d91bb34278d2c4d6996
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - User-Agent
-        state:
-          __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
-      content-type:
-      - application/json
-    method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
-  response:
-    body:
-      string: '{"task":"/pulp/api/v3/tasks/019dcf79-cce4-70c0-8806-671eb4c24725/"}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 178dc40fce874d91bb34278d2c4d6996
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Mon, 27 Apr 2026 15:05:59 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - Accept
-        state:
-          __istr_identity__: Accept
-      : - application/json
-      Accept-Encoding:
-      - gzip, deflate, zstd
-      Connection:
-      - keep-alive
-      Correlation-Id:
-      - 178dc40fce874d91bb34278d2c4d6996
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - User-Agent
-        state:
-          __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019dcf79-cce4-70c0-8806-671eb4c24725/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019dcf79-cce4-70c0-8806-671eb4c24725/","prn":"prn:core.task:019dcf79-cce4-70c0-8806-671eb4c24725","pulp_created":"2026-04-27T15:05:59.276393Z","pulp_last_updated":"2026-04-27T15:05:59.269364Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"178dc40fce874d91bb34278d2c4d6996","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-04-27T15:05:59.317317Z","started_at":"2026-04-27T15:05:59.329729Z","finished_at":"2026-04-27T15:05:59.365122Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","shared:prn:core.domain:34336c95-92ee-446b-adae-1152e7ac1ddd"],"result":{"prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","name":"test_file_repository","remote":null,"manifest":"PULP_MANIFEST","pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","autopublish":true,"description":null,"pulp_labels":{},"pulp_created":"2026-04-27T15:05:36.186130Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_last_updated":"2026-04-27T15:05:59.347748Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","retain_repo_versions":null}}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1474'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 178dc40fce874d91bb34278d2c4d6996
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Mon, 27 Apr 2026 15:05:59 GMT
-      Referrer-Policy:
-      - same-origin
-      Server:
-      - nginx/1.22.1
-      Vary:
-      - Accept
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - Accept
-        state:
-          __istr_identity__: Accept
-      : - application/json
-      Accept-Encoding:
-      - gzip, deflate, zstd
-      Connection:
-      - keep-alive
-      Correlation-Id:
-      - 178dc40fce874d91bb34278d2c4d6996
-      ? !!python/object/new:multidict._multidict_py.istr
-        args:
-        - User-Agent
-        state:
-          __istr_identity__: User-Agent
-      : - Squeezer/0.3.0-dev
-    method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/
-  response:
-    body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/","prn":"prn:file.filerepository:019dcf79-72b5-7dc7-b6cf-1e6e554e19af","pulp_created":"2026-04-27T15:05:36.186130Z","pulp_last_updated":"2026-04-27T15:05:59.347748Z","versions_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/file/file/019dcf79-72b5-7dc7-b6cf-1e6e554e19af/versions/0/","name":"test_file_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":null,"autopublish":true,"manifest":"PULP_MANIFEST"}'
-    headers:
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '643'
-      Content-Type:
-      - application/json
-      Correlation-ID:
-      - 178dc40fce874d91bb34278d2c4d6996
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Date:
-      - Mon, 27 Apr 2026 15:06:00 GMT
+      - Mon, 25 May 2026 19:18:12 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-0.yml
+++ b/tests/fixtures/rpm_repository-0.yml
@@ -2,15 +2,21 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/docs/api.json
@@ -24,13 +30,13 @@ interactions:
         {\n            \"url\": \"https://raw.githubusercontent.com/pulp/pulpcore/master/LICENSE\",\n
         \           \"name\": \"GNU General Public License v2.0 or later\"\n        },\n
         \       \"x-logo\": {\n            \"url\": \"https://pulpproject.org/assets/pulp_logo_icon.svg\"\n
-        \       },\n        \"x-pulp-app-versions\": {\n            \"core\": \"3.110.1\",\n
-        \           \"ansible\": \"0.29.8\",\n            \"container\": \"2.27.8\",\n
-        \           \"deb\": \"3.8.1\",\n            \"gem\": \"0.7.5\",\n            \"hugging_face\":
-        \"0.3.0\",\n            \"maven\": \"0.12.0\",\n            \"npm\": \"0.7.1\",\n
-        \           \"ostree\": \"2.6.0\",\n            \"python\": \"3.29.0\",\n
-        \           \"rpm\": \"3.36.0\",\n            \"certguard\": \"3.110.1\",\n
-        \           \"file\": \"3.110.1\"\n        },\n        \"x-pulp-domain-enabled\":
+        \       },\n        \"x-pulp-app-versions\": {\n            \"core\": \"3.111.1\",\n
+        \           \"ansible\": \"0.29.8\",\n            \"container\": \"2.27.9\",\n
+        \           \"deb\": \"3.8.2\",\n            \"gem\": \"0.7.5\",\n            \"hugging_face\":
+        \"0.3.0\",\n            \"maven\": \"0.12.0\",\n            \"npm\": \"0.8.0\",\n
+        \           \"ostree\": \"2.6.0\",\n            \"python\": \"3.30.0\",\n
+        \           \"rpm\": \"3.36.0\",\n            \"certguard\": \"3.111.1\",\n
+        \           \"file\": \"3.111.1\"\n        },\n        \"x-pulp-domain-enabled\":
         false\n    },\n    \"paths\": {\n        \"/ansible/collections/\": {\n            \"post\":
         {\n                \"operationId\": \"upload_collection\",\n                \"description\":
         \"Create an artifact and trigger an asynchronous task to create Collection
@@ -58,10 +64,88 @@ interactions:
         \"#/components/schemas/AsyncOperationResponse\"\n                                }\n
         \                           }\n                        },\n                        \"description\":
         \"\"\n                    }\n                }\n            }\n        },\n
-        \       \"/pulp/api/v3/access_policies/\": {\n            \"get\": {\n                \"operationId\":
-        \"access_policies_list\",\n                \"description\": \"ViewSet for
-        AccessPolicy.\",\n                \"summary\": \"List access policys\",\n
-        \               \"parameters\": [\n                    {\n                        \"in\":
+        \       \"/npm/{path}/{package_name}\": {\n            \"put\": {\n                \"operationId\":
+        \"npm_put\",\n                \"description\": \"Handle npm/yarn publish requests
+        (``PUT /``).\",\n                \"parameters\": [\n                    {\n
+        \                       \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"package_name\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^@[^/]+%2[Ff][^/]+|@[^/]+/[^/]+|[^/@][^/]*$\"\n
+        \                       },\n                        \"required\": true\n                    },\n
+        \                   {\n                        \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    }\n                ],\n
+        \               \"tags\": [\n                    \"Npm\"\n                ],\n
+        \               \"security\": [\n                    {\n                        \"basicAuth\":
+        []\n                    },\n                    {\n                        \"cookieAuth\":
+        []\n                    }\n                ],\n                \"responses\":
+        {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/npm/{path}/-/ping\": {\n            \"get\": {\n                \"operationId\":
+        \"npm___ping_get\",\n                \"description\": \"Handle ``GET /-/ping``
+        -- registry health check.\",\n                \"parameters\": [\n                    {\n
+        \                       \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to include in the response.\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to exclude from the response.\"\n                    }\n
+        \               ],\n                \"tags\": [\n                    \"Npm:
+        Ping\"\n                ],\n                \"security\": [\n                    {\n
+        \                       \"basicAuth\": []\n                    },\n                    {\n
+        \                       \"cookieAuth\": []\n                    }\n                ],\n
+        \               \"responses\": {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/npm/{path}/-/whoami\": {\n            \"get\": {\n
+        \               \"operationId\": \"npm___whoami_get\",\n                \"description\":
+        \"Handle ``GET /-/whoami`` -- return the authenticated user.\",\n                \"parameters\":
+        [\n                    {\n                        \"in\": \"header\",\n                        \"name\":
+        \"X-Task-Diagnostics\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"List of profilers to use on tasks.\"\n                    },\n                    {\n
+        \                       \"in\": \"path\",\n                        \"name\":
+        \"path\",\n                        \"schema\": {\n                            \"type\":
+        \"string\",\n                            \"pattern\": \"^.+?$\"\n                        },\n
+        \                       \"required\": true\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to include in the response.\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"A list of fields to exclude from the response.\"\n                    }\n
+        \               ],\n                \"tags\": [\n                    \"Npm:
+        Whoami\"\n                ],\n                \"security\": [\n                    {\n
+        \                       \"basicAuth\": []\n                    },\n                    {\n
+        \                       \"cookieAuth\": []\n                    }\n                ],\n
+        \               \"responses\": {\n                    \"200\": {\n                        \"description\":
+        \"No response body\"\n                    }\n                }\n            }\n
+        \       },\n        \"/pulp/api/v3/access_policies/\": {\n            \"get\":
+        {\n                \"operationId\": \"access_policies_list\",\n                \"description\":
+        \"ViewSet for AccessPolicy.\",\n                \"summary\": \"List access
+        policys\",\n                \"parameters\": [\n                    {\n                        \"in\":
         \"header\",\n                        \"name\": \"X-Task-Diagnostics\",\n                        \"schema\":
         {\n                            \"type\": \"array\",\n                            \"items\":
         {\n                                \"type\": \"string\"\n                            }\n
@@ -48893,25 +48977,83 @@ interactions:
         \"array\",\n                            \"items\": {\n                                \"type\":
         \"string\"\n                            }\n                        },\n                        \"description\":
         \"List of profilers to use on tasks.\"\n                    },\n                    {\n
-        \                       \"name\": \"limit\",\n                        \"required\":
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"filename\",\n                        \"schema\": {\n                            \"type\":
+        \"string\"\n                        },\n                        \"description\":
+        \"Filter results where filename matches value\"\n                    },\n
+        \                   {\n                        \"name\": \"limit\",\n                        \"required\":
         false,\n                        \"in\": \"query\",\n                        \"description\":
         \"Number of results to return per page.\",\n                        \"schema\":
         {\n                            \"type\": \"integer\"\n                        }\n
-        \                   },\n                    {\n                        \"name\":
+        \                   },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"name\",\n                        \"schema\":
+        {\n                            \"type\": \"string\"\n                        },\n
+        \                       \"description\": \"Filter results where name matches
+        value\"\n                    },\n                    {\n                        \"name\":
         \"offset\",\n                        \"required\": false,\n                        \"in\":
         \"query\",\n                        \"description\": \"The initial index from
         which to return the results.\",\n                        \"schema\": {\n                            \"type\":
         \"integer\"\n                        }\n                    },\n                    {\n
-        \                       \"in\": \"path\",\n                        \"name\":
+        \                       \"in\": \"query\",\n                        \"name\":
+        \"ordering\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\",\n                                \"enum\": [\n                                    \"-added_by\",\n
+        \                                   \"-filename\",\n                                    \"-name\",\n
+        \                                   \"-pk\",\n                                    \"-pulp_created\",\n
+        \                                   \"-pulp_id\",\n                                    \"-pulp_last_updated\",\n
+        \                                   \"-version\",\n                                    \"added_by\",\n
+        \                                   \"filename\",\n                                    \"name\",\n
+        \                                   \"pk\",\n                                    \"pulp_created\",\n
+        \                                   \"pulp_id\",\n                                    \"pulp_last_updated\",\n
+        \                                   \"version\"\n                                ]\n
+        \                           }\n                        },\n                        \"description\":
+        \"Ordering\\n\\n* `pulp_id` - Pulp id\\n* `-pulp_id` - Pulp id (descending)\\n*
+        `pulp_created` - Pulp created\\n* `-pulp_created` - Pulp created (descending)\\n*
+        `pulp_last_updated` - Pulp last updated\\n* `-pulp_last_updated` - Pulp last
+        updated (descending)\\n* `name` - Name\\n* `-name` - Name (descending)\\n*
+        `version` - Version\\n* `-version` - Version (descending)\\n* `filename` -
+        Filename\\n* `-filename` - Filename (descending)\\n* `added_by` - Added by\\n*
+        `-added_by` - Added by (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n
+        \                       \"explode\": false,\n                        \"style\":
+        \"form\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"prn__in\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"pulp_href__in\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\"\n                            }\n                        },\n                        \"description\":
+        \"Multiple values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"pulp_id__in\",\n                        \"schema\": {\n                            \"type\":
+        \"array\",\n                            \"items\": {\n                                \"type\":
+        \"string\",\n                                \"format\": \"uuid\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
+        false,\n                        \"style\": \"form\"\n                    },\n
+        \                   {\n                        \"in\": \"path\",\n                        \"name\":
         \"python_python_repository_href\",\n                        \"schema\": {\n
         \                           \"type\": \"string\"\n                        },\n
         \                       \"required\": true\n                    },\n                    {\n
         \                       \"in\": \"query\",\n                        \"name\":
-        \"fields\",\n                        \"schema\": {\n                            \"type\":
-        \"array\",\n                            \"items\": {\n                                \"type\":
-        \"string\"\n                            }\n                        },\n                        \"description\":
-        \"A list of fields to include in the response.\"\n                    },\n
-        \                   {\n                        \"in\": \"query\",\n                        \"name\":
+        \"q\",\n                        \"schema\": {\n                            \"type\":
+        \"string\"\n                        },\n                        \"description\":
+        \"Filter results by using NOT, AND and OR operations on other filters\"\n
+        \                   },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"version\",\n                        \"schema\":
+        {\n                            \"type\": \"string\"\n                        },\n
+        \                       \"description\": \"Filter results where version matches
+        value\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"fields\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"A list
+        of fields to include in the response.\"\n                    },\n                    {\n
+        \                       \"in\": \"query\",\n                        \"name\":
         \"exclude_fields\",\n                        \"schema\": {\n                            \"type\":
         \"array\",\n                            \"items\": {\n                                \"type\":
         \"string\"\n                            }\n                        },\n                        \"description\":
@@ -52347,21 +52489,27 @@ interactions:
         {\n                                \"type\": \"string\",\n                                \"enum\":
         [\n                                    \"-api_root\",\n                                    \"-base_url\",\n
         \                                   \"-ca_cert\",\n                                    \"-client_cert\",\n
-        \                                   \"-client_key\",\n                                    \"-domain\",\n
-        \                                   \"-last_replication\",\n                                    \"-name\",\n
-        \                                   \"-password\",\n                                    \"-pk\",\n
-        \                                   \"-policy\",\n                                    \"-pulp_created\",\n
-        \                                   \"-pulp_id\",\n                                    \"-pulp_last_updated\",\n
-        \                                   \"-q_select\",\n                                    \"-tls_validation\",\n
+        \                                   \"-client_key\",\n                                    \"-connect_timeout\",\n
+        \                                   \"-domain\",\n                                    \"-download_concurrency\",\n
+        \                                   \"-last_replication\",\n                                    \"-max_retries\",\n
+        \                                   \"-name\",\n                                    \"-password\",\n
+        \                                   \"-pk\",\n                                    \"-policy\",\n
+        \                                   \"-pulp_created\",\n                                    \"-pulp_id\",\n
+        \                                   \"-pulp_last_updated\",\n                                    \"-q_select\",\n
+        \                                   \"-sock_connect_timeout\",\n                                    \"-sock_read_timeout\",\n
+        \                                   \"-tls_validation\",\n                                    \"-total_timeout\",\n
         \                                   \"-username\",\n                                    \"api_root\",\n
         \                                   \"base_url\",\n                                    \"ca_cert\",\n
         \                                   \"client_cert\",\n                                    \"client_key\",\n
-        \                                   \"domain\",\n                                    \"last_replication\",\n
-        \                                   \"name\",\n                                    \"password\",\n
-        \                                   \"pk\",\n                                    \"policy\",\n
-        \                                   \"pulp_created\",\n                                    \"pulp_id\",\n
-        \                                   \"pulp_last_updated\",\n                                    \"q_select\",\n
-        \                                   \"tls_validation\",\n                                    \"username\"\n
+        \                                   \"connect_timeout\",\n                                    \"domain\",\n
+        \                                   \"download_concurrency\",\n                                    \"last_replication\",\n
+        \                                   \"max_retries\",\n                                    \"name\",\n
+        \                                   \"password\",\n                                    \"pk\",\n
+        \                                   \"policy\",\n                                    \"pulp_created\",\n
+        \                                   \"pulp_id\",\n                                    \"pulp_last_updated\",\n
+        \                                   \"q_select\",\n                                    \"sock_connect_timeout\",\n
+        \                                   \"sock_read_timeout\",\n                                    \"tls_validation\",\n
+        \                                   \"total_timeout\",\n                                    \"username\"\n
         \                               ]\n                            }\n                        },\n
         \                       \"description\": \"Ordering\\n\\n* `pulp_id` - Pulp
         id\\n* `-pulp_id` - Pulp id (descending)\\n* `pulp_created` - Pulp created\\n*
@@ -52375,16 +52523,24 @@ interactions:
         - Client key\\n* `-client_key` - Client key (descending)\\n* `tls_validation`
         - Tls validation\\n* `-tls_validation` - Tls validation (descending)\\n* `username`
         - Username\\n* `-username` - Username (descending)\\n* `password` - Password\\n*
-        `-password` - Password (descending)\\n* `q_select` - Q select\\n* `-q_select`
-        - Q select (descending)\\n* `policy` - Policy\\n* `-policy` - Policy (descending)\\n*
-        `last_replication` - Last replication\\n* `-last_replication` - Last replication
-        (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n                        \"explode\":
-        false,\n                        \"style\": \"form\"\n                    },\n
-        \                   {\n                        \"in\": \"query\",\n                        \"name\":
-        \"prn__in\",\n                        \"schema\": {\n                            \"type\":
-        \"array\",\n                            \"items\": {\n                                \"type\":
-        \"string\"\n                            }\n                        },\n                        \"description\":
-        \"Multiple values may be separated by commas.\",\n                        \"explode\":
+        `-password` - Password (descending)\\n* `download_concurrency` - Download
+        concurrency\\n* `-download_concurrency` - Download concurrency (descending)\\n*
+        `max_retries` - Max retries\\n* `-max_retries` - Max retries (descending)\\n*
+        `total_timeout` - Total timeout\\n* `-total_timeout` - Total timeout (descending)\\n*
+        `connect_timeout` - Connect timeout\\n* `-connect_timeout` - Connect timeout
+        (descending)\\n* `sock_connect_timeout` - Sock connect timeout\\n* `-sock_connect_timeout`
+        - Sock connect timeout (descending)\\n* `sock_read_timeout` - Sock read timeout\\n*
+        `-sock_read_timeout` - Sock read timeout (descending)\\n* `q_select` - Q select\\n*
+        `-q_select` - Q select (descending)\\n* `policy` - Policy\\n* `-policy` -
+        Policy (descending)\\n* `last_replication` - Last replication\\n* `-last_replication`
+        - Last replication (descending)\\n* `pk` - Pk\\n* `-pk` - Pk (descending)\",\n
+        \                       \"explode\": false,\n                        \"style\":
+        \"form\"\n                    },\n                    {\n                        \"in\":
+        \"query\",\n                        \"name\": \"prn__in\",\n                        \"schema\":
+        {\n                            \"type\": \"array\",\n                            \"items\":
+        {\n                                \"type\": \"string\"\n                            }\n
+        \                       },\n                        \"description\": \"Multiple
+        values may be separated by commas.\",\n                        \"explode\":
         false,\n                        \"style\": \"form\"\n                    },\n
         \                   {\n                        \"in\": \"query\",\n                        \"name\":
         \"pulp_href__in\",\n                        \"schema\": {\n                            \"type\":
@@ -58568,48 +58724,49 @@ interactions:
         \               ]\n            },\n            \"ArtifactDistributionResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for ArtifactDistribution.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"base_url\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The URL for accessing the
-        publication as defined by this distribution.\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"no_content_change_since\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"base_path\": {\n                        \"type\":
+        \"string\",\n                        \"description\": \"The base (relative)
+        path component of the published url. Avoid paths that                     overlap
+        with other distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n
+        \                   },\n                    \"no_content_change_since\": {\n
+        \                       \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp since when the
         distributed content served by this distribution has not changed. If equals
         to `null`, no guarantee is provided about content changes.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"An optional content-guard.\"\n
-        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of the last time
-        this resource was updated. Note: for immutable resources - like content, repository
-        versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"description\": \"The base (relative) path component
-        of the published url. Avoid paths that                     overlap with other
-        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
         \                   \"pulp_created\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"content_guard_prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
+        of the associated optional content guard.\"\n                    },\n                    \"hidden\":
+        {\n                        \"type\": \"boolean\",\n                        \"default\":
+        false,\n                        \"description\": \"Whether this distribution
+        should be shown in the content app.\"\n                    },\n                    \"pulp_last_updated\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of the last time this resource was updated. Note: for immutable
+        resources - like content, repository versions, and publication - pulp_created
+        and pulp_last_updated dates will be the same.\"\n                    },\n
+        \                   \"base_url\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The URL for accessing the publication as defined by this distribution.\"\n
+        \                   },\n                    \"content_guard\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"An optional content-guard.\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"description\": \"A unique name. Ex,
+        `rawhide` and `stable`.\"\n                    },\n                    \"prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
         \                   }\n                },\n                \"required\": [\n
         \                   \"base_path\",\n                    \"name\"\n                ]\n
         \           },\n            \"ArtifactRefResponse\": {\n                \"type\":
@@ -59307,30 +59464,35 @@ interactions:
         `windows` - windows\\n* `macos` - macos\\n* `freebsd` - freebsd\\n* `linux`
         - linux\"\n            },\n            \"FileContentUpload\": {\n                \"type\":
         \"object\",\n                \"description\": \"Serializer for File Content.\",\n
-        \               \"properties\": {\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        \               \"properties\": {\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -60077,31 +60239,36 @@ interactions:
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for synchronous npm package uploads.\\n\\nHandles file-to-artifact
         conversion and metadata extraction in a single\\nrequest instead of dispatching
-        an async task.\",\n                \"properties\": {\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path. If not provided, it will be computed
-        from name and version.\"\n                    },\n                    \"file\":
+        an async task.\",\n                \"properties\": {\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path.
+        If not provided, it will be computed from name and version.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -60313,13 +60480,19 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -63027,7 +63200,36 @@ interactions:
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to be used for
         authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"q_select\":
+        are not trimmed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"q_select\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"description\": \"Filter distributions on
         the upstream Pulp using complex filtering. E.g. pulp_label_select=\\\"foo\\\"
@@ -63094,7 +63296,7 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         3,\n                        \"description\": \"Required named, only accepts
         lowercase, numbers and underscores.\",\n                        \"maxLength\":
-        64,\n                        \"pattern\": \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n
+        64,\n                        \"pattern\": \"^(?!.*__)[a-z][0-9a-z_]*$\"\n
         \                   },\n                    \"company\": {\n                        \"type\":
         \"string\",\n                        \"description\": \"Optional namespace
         company owner.\",\n                        \"maxLength\": 64\n                    },\n
@@ -63252,89 +63454,89 @@ interactions:
         that have a signature\"\n                    }\n                }\n            },\n
         \           \"Patchedansible.GitRemote\": {\n                \"type\": \"object\",\n
         \               \"description\": \"A serializer for Git Collection Remotes.\",\n
-        \               \"properties\": {\n                    \"client_key\": {\n
-        \                       \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded private key used
-        for authentication.\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name for this remote.\"\n
-        \                   },\n                    \"sock_connect_timeout\": {\n
-        \                       \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"headers\":
+        \               \"properties\": {\n                    \"proxy_url\": {\n
+        \                       \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"headers\":
         {\n                        \"type\": \"array\",\n                        \"items\":
         {\n                            \"type\": \"object\"\n                        },\n
         \                       \"description\": \"Headers for aiohttp.Clientsession\"\n
-        \                   },\n                    \"client_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded client certificate
-        used for authentication.\"\n                    },\n                    \"sock_read_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_url\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        \                   },\n                    \"client_key\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"download_concurrency\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Total number of simultaneous connections. If not set then the default value
-        will be used.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"total_timeout\": {\n                        \"type\":
+        \"A PEM encoded private key used for authentication.\"\n                    },\n
+        \                   \"sock_read_timeout\": {\n                        \"type\":
         \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
         0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
+        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
         is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"proxy_password\":
+        \                   },\n                    \"proxy_username\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to authenticte to the proxy.\"\n                    },\n                    \"password\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"The password to be used for
+        authentication when syncing. Extra leading and trailing whitespace characters
+        are not trimmed.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_password\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to authenticate
         to the proxy. Extra leading and trailing whitespace characters are not trimmed.\"\n
-        \                   },\n                    \"max_retries\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Maximum number of retry
-        attempts after a download failure. If not set then the default value (3) will
-        be used.\"\n                    },\n                    \"password\": {\n
-        \                       \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The password to be used for
-        authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to be used for
-        authentication when syncing.\"\n                    },\n                    \"tls_validation\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, TLS peer validation must be performed.\"\n                    },\n
-        \                   \"connect_timeout\": {\n                        \"type\":
-        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
-        0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
-        is null, which will cause the default from the aiohttp library to be used.\"\n
         \                   },\n                    \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"ca_cert\": {\n                        \"type\":
+        \                   },\n                    \"download_concurrency\": {\n
+        \                       \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"sock_connect_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The
+        default is null, which will cause the default from the aiohttp library to
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"tls_validation\":
+        {\n                        \"type\": \"boolean\",\n                        \"description\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"username\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to be used for authentication when syncing.\"\n                    },\n
+        \                   \"client_cert\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A PEM encoded client certificate
+        used for authentication.\"\n                    },\n                    \"url\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The URL of an external content
+        source.\"\n                    },\n                    \"ca_cert\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"A PEM encoded CA certificate
         used to validate the server certificate presented by the remote server.\"\n
-        \                   },\n                    \"url\": {\n                        \"type\":
+        \                   },\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"The URL of an external content source.\"\n                    },\n                    \"proxy_username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to authenticte
-        to the proxy.\"\n                    },\n                    \"metadata_only\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, only metadata about the content will be stored in Pulp. Clients
-        will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
+        \"A unique name for this remote.\"\n                    },\n                    \"rate_limit\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Limits requests per second for each concurrent downloader\"\n                    },\n
+        \                   \"metadata_only\": {\n                        \"type\":
+        \"boolean\",\n                        \"description\": \"If True, only metadata
+        about the content will be stored in Pulp. Clients will retrieve content from
+        the remote URL.\"\n                    },\n                    \"git_ref\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"A git ref. e.g.: branch, tag,
         or commit sha.\"\n                    }\n                }\n            },\n
@@ -63451,66 +63653,65 @@ interactions:
         \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerDistribution\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for ContainerDistribution.\",\n                \"properties\":
-        {\n                    \"repository_version\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"RepositoryVersion to be
-        served\"\n                    },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"base_path\": {\n                        \"type\":
+        {\n                    \"base_path\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"The base (relative) path component of the published url. Avoid paths that
         \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository\":
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository_version\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"RepositoryVersion to be served\"\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"private\": {\n                        \"type\": \"boolean\",\n
-        \                       \"description\": \"Restrict pull access to explicitly
-        authorized users. Defaults to unrestricted pull access.\"\n                    },\n
-        \                   \"description\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"An optional description.\"\n
-        \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerPullThroughDistribution\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
-        \               \"properties\": {\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name. Ex, `rawhide`
-        and `stable`.\"\n                    },\n                    \"hidden\": {\n
-        \                       \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
-        \                   \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"base_path\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"content_guard\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
+        \"An optional content-guard. If none is specified, a default one will be used.\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"private\":
+        {\n                        \"type\": \"boolean\",\n                        \"description\":
+        \"Restrict pull access to explicitly authorized users. Defaults to unrestricted
+        pull access.\"\n                    },\n                    \"description\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"An optional description.\"\n                    }\n                }\n            },\n
+        \           \"Patchedcontainer.ContainerPullThroughDistribution\": {\n                \"type\":
+        \"object\",\n                \"description\": \"A serializer for a specialized
+        pull-through distribution referencing sub-distributions.\",\n                \"properties\":
+        {\n                    \"base_path\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"The base (relative) path component of the published url. Avoid paths that
         \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository\":
+        and \\\"foo/bar\\\")\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository_version\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"RepositoryVersion to be served\"\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"remote\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Remote that can be used to fetch content when using pull-through caching.\"\n
-        \                   },\n                    \"distributions\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"content_guard\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
+        \"An optional content-guard. If none is specified, a default one will be used.\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"remote\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Remote that can be used
+        to fetch content when using pull-through caching.\"\n                    },\n
+        \                   \"distributions\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"type\":
         \"string\",\n                            \"format\": \"uri\"\n                        },\n
         \                       \"description\": \"Distributions created after pulling
@@ -63624,26 +63825,27 @@ interactions:
         \           },\n            \"Patchedcontainer.ContainerPushRepository\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this repository.\"\n                    },\n                    \"retain_repo_versions\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
+        {\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"retain_checkpoints\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Retain X checkpoint publications
+        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
+        1\n                    },\n                    \"retain_repo_versions\": {\n
+        \                       \"type\": \"integer\",\n                        \"format\":
         \"int64\",\n                        \"nullable\": true,\n                        \"description\":
         \"Retain X versions of the repository. Default is null which retains all versions.\",\n
-        \                       \"minimum\": 1\n                    },\n                    \"manifest_signing_service\":
+        \                       \"minimum\": 1\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"A unique name for this repository.\"\n
+        \                   },\n                    \"manifest_signing_service\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"A reference to an associated signing service.\"\n                    },\n
         \                   \"description\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"An optional description.\"\n
-        \                   },\n                    \"retain_checkpoints\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Retain X checkpoint publications
-        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
-        1\n                    },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
         \                   }\n                }\n            },\n            \"Patchedcontainer.ContainerRemote\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ContainerRemote.\",\n                \"properties\": {\n
@@ -65855,7 +66057,7 @@ interactions:
         \               ]\n            },\n            \"Purge\": {\n                \"type\":
         \"object\",\n                \"properties\": {\n                    \"finished_before\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"default\": \"2026-04-08\",\n                        \"description\":
+        \"date-time\",\n                        \"default\": \"2026-04-18\",\n                        \"description\":
         \"Purge tasks completed earlier than this timestamp. Format '%Y-%m-%d[T%H:%M:%S]'\"\n
         \                   },\n                    \"states\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"$ref\":
@@ -65889,27 +66091,32 @@ interactions:
         \               ]\n            },\n            \"PythonPackageContentUpload\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for requests to synchronously upload Python packages.\",\n
-        \               \"properties\": {\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"file\":
+        \               \"properties\": {\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -66031,26 +66238,32 @@ interactions:
         [\n                    \"name\"\n                ]\n            },\n            \"RPMPackageUpload\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for requests to synchronously upload RPM packages.\",\n                \"properties\":
-        {\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        {\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -66297,7 +66510,12 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"description\": \"A repository version
         whose content will be used as the initial set of content for the new repository
-        version\"\n                    }\n                }\n            },\n            \"RepositoryResponse\":
+        version\"\n                    },\n                    \"overwrite\": {\n
+        \                       \"type\": \"boolean\",\n                        \"default\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Defaults
+        to true.\"\n                    }\n                }\n            },\n            \"RepositoryResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Base serializer for use with [pulpcore.app.models.Model][]\\n\\nThis ensures
         that all Serializers provide values for the 'pulp_href` field.\\n\\nThe class
@@ -66988,7 +67206,36 @@ interactions:
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to be used for
         authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"q_select\":
+        are not trimmed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"q_select\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"description\": \"Filter distributions on
         the upstream Pulp using complex filtering. E.g. pulp_label_select=\\\"foo\\\"
@@ -67035,7 +67282,36 @@ interactions:
         \"A PEM encoded client certificate used for authentication.\"\n                    },\n
         \                   \"tls_validation\": {\n                        \"type\":
         \"boolean\",\n                        \"description\": \"If True, TLS peer
-        validation must be performed.\"\n                    },\n                    \"hidden_fields\":
+        validation must be performed.\"\n                    },\n                    \"download_concurrency\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"max_retries\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Maximum number of retry
+        attempts after a download failure. If not set then the default value (3) will
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"sock_read_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"hidden_fields\":
         {\n                        \"type\": \"array\",\n                        \"items\":
         {\n                            \"type\": \"object\",\n                            \"properties\":
         {\n                                \"name\": {\n                                    \"type\":
@@ -67311,13 +67587,18 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"The name of the Collection.\"\n                    },\n                    \"namespace\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"The namespace of the Collection.\"\n
@@ -67435,7 +67716,7 @@ interactions:
         \               \"properties\": {\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 3,\n                        \"description\":
         \"Required named, only accepts lowercase, numbers and underscores.\",\n                        \"maxLength\":
-        64,\n                        \"pattern\": \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n
+        64,\n                        \"pattern\": \"^(?!.*__)[a-z][0-9a-z_]*$\"\n
         \                   },\n                    \"company\": {\n                        \"type\":
         \"string\",\n                        \"description\": \"Optional namespace
         company owner.\",\n                        \"maxLength\": 64\n                    },\n
@@ -67464,7 +67745,7 @@ interactions:
         \                       \"description\": \"Required named, only accepts lowercase,
         numbers and underscores.\",\n                        \"maxLength\": 64,\n
         \                       \"minLength\": 3,\n                        \"pattern\":
-        \"^(?!.*__)[a-z]+[0-9a-z_]*$\"\n                    },\n                    \"company\":
+        \"^(?!.*__)[a-z][0-9a-z_]*$\"\n                    },\n                    \"company\":
         {\n                        \"type\": \"string\",\n                        \"description\":
         \"Optional namespace company owner.\",\n                        \"maxLength\":
         64\n                    },\n                    \"email\": {\n                        \"type\":
@@ -67785,23 +68066,7 @@ interactions:
         [\n                    \"name\",\n                    \"namespace\"\n                ]\n
         \           },\n            \"ansible.CollectionVersion\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for CollectionVersion
-        Content.\",\n                \"properties\": {\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
-        \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
-        \                       ],\n                        \"writeOnly\": true,\n
-        \                       \"description\": \"Configuration for the download
-        process (e.g., proxies, auth, timeouts). Only applicable when providing a
-        'file_url.\"\n                    },\n                    \"pulp_labels\":
+        Content.\",\n                \"properties\": {\n                    \"pulp_labels\":
         {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
         true\n                        },\n                        \"description\":
@@ -67809,19 +68074,40 @@ interactions:
         instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"repository\":
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"artifact\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"repository\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"expected_name\": {\n                        \"type\":
-        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The name of the collection.\",\n
-        \                       \"maxLength\": 64\n                    },\n                    \"expected_namespace\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
+        \                       ],\n                        \"writeOnly\": true,\n
+        \                       \"description\": \"Configuration for the download
+        process (e.g., proxies, auth, timeouts). Only applicable when providing a
+        'file_url.\"\n                    },\n                    \"expected_name\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"The namespace of the collection.\",\n                        \"maxLength\":
-        64\n                    },\n                    \"expected_version\": {\n
-        \                       \"type\": \"string\",\n                        \"writeOnly\":
+        \"The name of the collection.\",\n                        \"maxLength\": 64\n
+        \                   },\n                    \"expected_namespace\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"The namespace of the collection.\",\n
+        \                       \"maxLength\": 64\n                    },\n                    \"expected_version\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"The version of the collection.\",\n                        \"maxLength\":
         128\n                    }\n                }\n            },\n            \"ansible.CollectionVersionMark\":
@@ -67852,42 +68138,41 @@ interactions:
         \               ]\n            },\n            \"ansible.CollectionVersionResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for CollectionVersion Content.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"artifact\":
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of the last time
+        this resource was updated. Note: for immutable resources - like content, repository
+        versions, and publication - pulp_created and pulp_last_updated dates will
+        be the same.\"\n                    },\n                    \"artifact\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"description\": \"Artifact file representing
         the physical content\"\n                    },\n                    \"vuln_report\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"pulp_last_updated\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of the last time
-        this resource was updated. Note: for immutable resources - like content, repository
-        versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"pulp_href\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"pulp_created\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"sha256\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"The SHA-256 checksum if available.\"\n                    },\n                    \"md5\":
+        \                   \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"sha256\":
         {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The MD5 checksum if available.\"\n
-        \                   },\n                    \"sha1\": {\n                        \"type\":
+        true,\n                        \"description\": \"The SHA-256 checksum if
+        available.\"\n                    },\n                    \"md5\": {\n                        \"type\":
         \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"The SHA-1 checksum if available.\"\n                    },\n                    \"sha224\":
+        \"The MD5 checksum if available.\"\n                    },\n                    \"sha1\":
         {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The SHA-224 checksum if
-        available.\"\n                    },\n                    \"sha384\": {\n
-        \                       \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The SHA-1 checksum if available.\"\n
+        \                   },\n                    \"sha224\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The SHA-224 checksum if available.\"\n                    },\n                    \"sha384\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"The SHA-384 checksum if
         available.\"\n                    },\n                    \"sha512\": {\n
         \                       \"type\": \"string\",\n                        \"readOnly\":
@@ -67951,13 +68236,19 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -68014,157 +68305,120 @@ interactions:
         [\n                    \"signed_collection\"\n                ]\n            },\n
         \           \"ansible.GitRemote\": {\n                \"type\": \"object\",\n
         \               \"description\": \"A serializer for Git Collection Remotes.\",\n
-        \               \"properties\": {\n                    \"client_key\": {\n
-        \                       \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded private key used
-        for authentication.\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name for this remote.\"\n
-        \                   },\n                    \"sock_connect_timeout\": {\n
-        \                       \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"headers\":
+        \               \"properties\": {\n                    \"proxy_url\": {\n
+        \                       \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"headers\":
         {\n                        \"type\": \"array\",\n                        \"items\":
         {\n                            \"type\": \"object\"\n                        },\n
         \                       \"description\": \"Headers for aiohttp.Clientsession\"\n
-        \                   },\n                    \"client_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A PEM encoded client certificate
-        used for authentication.\"\n                    },\n                    \"sock_read_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_read
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_url\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        \                   },\n                    \"client_key\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"The proxy URL. Format: scheme://host:port\"\n                    },\n                    \"download_concurrency\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Total number of simultaneous connections. If not set then the default value
-        will be used.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"total_timeout\": {\n                        \"type\":
+        \"A PEM encoded private key used for authentication.\"\n                    },\n
+        \                   \"sock_read_timeout\": {\n                        \"type\":
         \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
         0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
+        \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
         is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"proxy_password\":
+        \                   },\n                    \"proxy_username\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to authenticte to the proxy.\"\n                    },\n                    \"password\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"The password to be used for
+        authentication when syncing. Extra leading and trailing whitespace characters
+        are not trimmed.\"\n                    },\n                    \"connect_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.connect
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"proxy_password\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"The password to authenticate
         to the proxy. Extra leading and trailing whitespace characters are not trimmed.\"\n
-        \                   },\n                    \"max_retries\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Maximum number of retry
-        attempts after a download failure. If not set then the default value (3) will
-        be used.\"\n                    },\n                    \"password\": {\n
-        \                       \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The password to be used for
-        authentication when syncing. Extra leading and trailing whitespace characters
-        are not trimmed.\"\n                    },\n                    \"username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to be used for
-        authentication when syncing.\"\n                    },\n                    \"tls_validation\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, TLS peer validation must be performed.\"\n                    },\n
-        \                   \"connect_timeout\": {\n                        \"type\":
-        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
-        0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
-        is null, which will cause the default from the aiohttp library to be used.\"\n
         \                   },\n                    \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"ca_cert\": {\n                        \"type\":
+        \                   },\n                    \"download_concurrency\": {\n
+        \                       \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"sock_connect_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The
+        default is null, which will cause the default from the aiohttp library to
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"tls_validation\":
+        {\n                        \"type\": \"boolean\",\n                        \"description\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"username\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"The username to be used for authentication when syncing.\"\n                    },\n
+        \                   \"client_cert\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A PEM encoded client certificate
+        used for authentication.\"\n                    },\n                    \"url\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The URL of an external content
+        source.\"\n                    },\n                    \"ca_cert\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"A PEM encoded CA certificate
         used to validate the server certificate presented by the remote server.\"\n
-        \                   },\n                    \"url\": {\n                        \"type\":
+        \                   },\n                    \"name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"The URL of an external content source.\"\n                    },\n                    \"proxy_username\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"The username to authenticte
-        to the proxy.\"\n                    },\n                    \"metadata_only\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, only metadata about the content will be stored in Pulp. Clients
-        will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
+        \"A unique name for this remote.\"\n                    },\n                    \"rate_limit\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Limits requests per second for each concurrent downloader\"\n                    },\n
+        \                   \"metadata_only\": {\n                        \"type\":
+        \"boolean\",\n                        \"description\": \"If True, only metadata
+        about the content will be stored in Pulp. Clients will retrieve content from
+        the remote URL.\"\n                    },\n                    \"git_ref\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"A git ref. e.g.: branch, tag,
         or commit sha.\"\n                    }\n                },\n                \"required\":
         [\n                    \"name\",\n                    \"url\"\n                ]\n
         \           },\n            \"ansible.GitRemoteResponse\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for Git Collection
-        Remotes.\",\n                \"properties\": {\n                    \"prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
-        \                   },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"description\": \"A unique name for
-        this remote.\"\n                    },\n                    \"sock_connect_timeout\":
-        {\n                        \"type\": \"number\",\n                        \"format\":
-        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
-        true,\n                        \"description\": \"aiohttp.ClientTimeout.sock_connect
-        (q.v.) for download-connections. The default is null, which will cause the
-        default from the aiohttp library to be used.\"\n                    },\n                    \"headers\":
-        {\n                        \"type\": \"array\",\n                        \"items\":
-        {\n                            \"type\": \"object\"\n                        },\n
-        \                       \"description\": \"Headers for aiohttp.Clientsession\"\n
-        \                   },\n                    \"client_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A PEM encoded client certificate used for authentication.\"\n                    },\n
+        Remotes.\",\n                \"properties\": {\n                    \"proxy_url\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"description\": \"The proxy URL. Format: scheme://host:port\"\n
+        \                   },\n                    \"headers\": {\n                        \"type\":
+        \"array\",\n                        \"items\": {\n                            \"type\":
+        \"object\"\n                        },\n                        \"description\":
+        \"Headers for aiohttp.Clientsession\"\n                    },\n                    \"pulp_href\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
         \                   \"sock_read_timeout\": {\n                        \"type\":
         \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
         0.0,\n                        \"nullable\": true,\n                        \"description\":
         \"aiohttp.ClientTimeout.sock_read (q.v.) for download-connections. The default
         is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of the most recent
-        update of the remote.\"\n                    },\n                    \"proxy_url\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"description\": \"The proxy URL. Format: scheme://host:port\"\n
-        \                   },\n                    \"download_concurrency\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Total number of simultaneous connections. If not set then the default value
-        will be used.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"total_timeout\": {\n                        \"type\":
-        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
-        0.0,\n                        \"nullable\": true,\n                        \"description\":
-        \"aiohttp.ClientTimeout.total (q.v.) for download-connections. The default
-        is null, which will cause the default from the aiohttp library to be used.\"\n
-        \                   },\n                    \"pulp_created\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"rate_limit\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Limits requests per second
-        for each concurrent downloader\"\n                    },\n                    \"hidden_fields\":
-        {\n                        \"type\": \"array\",\n                        \"items\":
-        {\n                            \"type\": \"object\",\n                            \"properties\":
-        {\n                                \"name\": {\n                                    \"type\":
-        \"string\"\n                                },\n                                \"is_set\":
-        {\n                                    \"type\": \"boolean\"\n                                }\n
-        \                           },\n                            \"required\":
-        [\n                                \"is_set\",\n                                \"name\"\n
-        \                           ]\n                        },\n                        \"readOnly\":
-        true,\n                        \"description\": \"List of hidden (write only)
-        fields\"\n                    },\n                    \"max_retries\": {\n
-        \                       \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Maximum number of retry attempts after a download failure. If not set then
-        the default value (3) will be used.\"\n                    },\n                    \"tls_validation\":
-        {\n                        \"type\": \"boolean\",\n                        \"description\":
-        \"If True, TLS peer validation must be performed.\"\n                    },\n
-        \                   \"connect_timeout\": {\n                        \"type\":
+        \                   },\n                    \"hidden_fields\": {\n                        \"type\":
+        \"array\",\n                        \"items\": {\n                            \"type\":
+        \"object\",\n                            \"properties\": {\n                                \"name\":
+        {\n                                    \"type\": \"string\"\n                                },\n
+        \                               \"is_set\": {\n                                    \"type\":
+        \"boolean\"\n                                }\n                            },\n
+        \                           \"required\": [\n                                \"is_set\",\n
+        \                               \"name\"\n                            ]\n
+        \                       },\n                        \"readOnly\": true,\n
+        \                       \"description\": \"List of hidden (write only) fields\"\n
+        \                   },\n                    \"connect_timeout\": {\n                        \"type\":
         \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
         0.0,\n                        \"nullable\": true,\n                        \"description\":
         \"aiohttp.ClientTimeout.connect (q.v.) for download-connections. The default
@@ -68172,15 +68426,52 @@ interactions:
         \                   },\n                    \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"ca_cert\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"A PEM encoded CA certificate used to validate the server certificate presented
-        by the remote server.\"\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"url\": {\n                        \"type\": \"string\",\n
-        \                       \"description\": \"The URL of an external content
-        source.\"\n                    },\n                    \"metadata_only\":
+        \                   },\n                    \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"download_concurrency\": {\n
+        \                       \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Total number of simultaneous connections. If not set then the default value
+        will be used.\",\n                        \"minimum\": 1\n                    },\n
+        \                   \"sock_connect_timeout\": {\n                        \"type\":
+        \"number\",\n                        \"format\": \"double\",\n                        \"minimum\":
+        0.0,\n                        \"nullable\": true,\n                        \"description\":
+        \"aiohttp.ClientTimeout.sock_connect (q.v.) for download-connections. The
+        default is null, which will cause the default from the aiohttp library to
+        be used.\"\n                    },\n                    \"total_timeout\":
+        {\n                        \"type\": \"number\",\n                        \"format\":
+        \"double\",\n                        \"minimum\": 0.0,\n                        \"nullable\":
+        true,\n                        \"description\": \"aiohttp.ClientTimeout.total
+        (q.v.) for download-connections. The default is null, which will cause the
+        default from the aiohttp library to be used.\"\n                    },\n                    \"max_retries\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Maximum number of retry attempts after a download failure. If not set then
+        the default value (3) will be used.\"\n                    },\n                    \"tls_validation\":
+        {\n                        \"type\": \"boolean\",\n                        \"description\":
+        \"If True, TLS peer validation must be performed.\"\n                    },\n
+        \                   \"pulp_last_updated\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of the most recent
+        update of the remote.\"\n                    },\n                    \"client_cert\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"description\": \"A PEM encoded client certificate
+        used for authentication.\"\n                    },\n                    \"url\":
+        {\n                        \"type\": \"string\",\n                        \"description\":
+        \"The URL of an external content source.\"\n                    },\n                    \"ca_cert\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"description\": \"A PEM encoded CA certificate
+        used to validate the server certificate presented by the remote server.\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"description\": \"A unique name for
+        this remote.\"\n                    },\n                    \"rate_limit\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Limits requests per second for each concurrent downloader\"\n                    },\n
+        \                   \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"metadata_only\":
         {\n                        \"type\": \"boolean\",\n                        \"description\":
         \"If True, only metadata about the content will be stored in Pulp. Clients
         will retrieve content from the remote URL.\"\n                    },\n                    \"git_ref\":
@@ -68190,34 +68481,39 @@ interactions:
         \                   \"url\"\n                ]\n            },\n            \"ansible.Role\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for Role versions.\",\n                \"properties\": {\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
         \                   \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        },\n
         \                       \"description\": \"A dictionary of arbitrary key/value
         pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"version\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"version\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1\n                    },\n                    \"name\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1\n                    },\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1\n                    },\n
-        \                   \"namespace\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    }\n                },\n
-        \               \"required\": [\n                    \"artifact\",\n                    \"name\",\n
-        \                   \"namespace\",\n                    \"version\"\n                ]\n
-        \           },\n            \"ansible.RoleRemote\": {\n                \"type\":
-        \"object\",\n                \"description\": \"A serializer for Ansible Remotes.\",\n
-        \               \"properties\": {\n                    \"name\": {\n                        \"type\":
+        1\n                    },\n                    \"namespace\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    }\n
+        \               },\n                \"required\": [\n                    \"artifact\",\n
+        \                   \"name\",\n                    \"namespace\",\n                    \"version\"\n
+        \               ]\n            },\n            \"ansible.RoleRemote\": {\n
+        \               \"type\": \"object\",\n                \"description\": \"A
+        serializer for Ansible Remotes.\",\n                \"properties\": {\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"A unique name for this remote.\"\n
+        \                   },\n                    \"url\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this remote.\"\n                    },\n                    \"url\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The URL of an external content
-        source.\"\n                    },\n                    \"pulp_labels\": {\n
-        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        \"The URL of an external content source.\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
         true\n                        }\n                    },\n                    \"policy\":
         {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
@@ -68384,53 +68680,53 @@ interactions:
         \               \"required\": [\n                    \"name\",\n                    \"url\"\n
         \               ]\n            },\n            \"ansible.RoleResponse\": {\n
         \               \"type\": \"object\",\n                \"description\": \"A
-        serializer for Role versions.\",\n                \"properties\": {\n                    \"prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
-        \                   },\n                    \"artifact\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"vuln_report\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"pulp_last_updated\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"Timestamp of the last time this resource was updated. Note: for immutable
-        resources - like content, repository versions, and publication - pulp_created
-        and pulp_last_updated dates will be the same.\"\n                    },\n
+        serializer for Role versions.\",\n                \"properties\": {\n                    \"pulp_href\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
         \                   \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        },\n
         \                       \"description\": \"A dictionary of arbitrary key/value
         pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"pulp_created\": {\n                        \"type\":
+        \                   \"pulp_created\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"version\": {\n                        \"type\":
-        \"string\"\n                    },\n                    \"name\": {\n                        \"type\":
-        \"string\"\n                    },\n                    \"namespace\": {\n
-        \                       \"type\": \"string\"\n                    }\n                },\n
-        \               \"required\": [\n                    \"artifact\",\n                    \"name\",\n
-        \                   \"namespace\",\n                    \"version\"\n                ]\n
-        \           },\n            \"certguard.RHSMCertGuard\": {\n                \"type\":
-        \"object\",\n                \"description\": \"RHSM Content Guard Serializer.\",\n
-        \               \"properties\": {\n                    \"name\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"The unique name.\"\n                    },\n                    \"description\":
-        {\n                        \"type\": \"string\",\n                        \"nullable\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"An optional description.\"\n                    },\n                    \"ca_certificate\":
+        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of the last time
+        this resource was updated. Note: for immutable resources - like content, repository
+        versions, and publication - pulp_created and pulp_last_updated dates will
+        be the same.\"\n                    },\n                    \"artifact\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"vuln_report\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        \                   \"prn\": {\n                        \"type\": \"string\",\n
+        \                       \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"version\":
+        {\n                        \"type\": \"string\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\"\n
+        \                   },\n                    \"namespace\": {\n                        \"type\":
+        \"string\"\n                    }\n                },\n                \"required\":
+        [\n                    \"artifact\",\n                    \"name\",\n                    \"namespace\",\n
+        \                   \"version\"\n                ]\n            },\n            \"certguard.RHSMCertGuard\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"RHSM Content Guard Serializer.\",\n                \"properties\": {\n                    \"name\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A Certificate Authority (CA)
-        certificate (or a bundle thereof) used to verify client-certificate authenticity.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"ca_certificate\",\n                    \"name\"\n                ]\n
-        \           },\n            \"certguard.RHSMCertGuardResponse\": {\n                \"type\":
-        \"object\",\n                \"description\": \"RHSM Content Guard Serializer.\",\n
-        \               \"properties\": {\n                    \"pulp_href\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
+        1,\n                        \"description\": \"The unique name.\"\n                    },\n
+        \                   \"description\": {\n                        \"type\":
+        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"An optional description.\"\n
+        \                   },\n                    \"ca_certificate\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A Certificate Authority (CA) certificate (or a bundle thereof) used to verify
+        client-certificate authenticity.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"ca_certificate\",\n
+        \                   \"name\"\n                ]\n            },\n            \"certguard.RHSMCertGuardResponse\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"RHSM Content Guard Serializer.\",\n                \"properties\": {\n                    \"pulp_href\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
         \                   \"prn\": {\n                        \"type\": \"string\",\n
         \                       \"readOnly\": true,\n                        \"description\":
@@ -68523,84 +68819,84 @@ interactions:
         [\n                    \"artifact\",\n                    \"digest\"\n                ]\n
         \           },\n            \"container.ContainerDistribution\": {\n                \"type\":
         \"object\",\n                \"description\": \"A serializer for ContainerDistribution.\",\n
-        \               \"properties\": {\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name. Ex, `rawhide`
-        and `stable`.\"\n                    },\n                    \"hidden\": {\n
-        \                       \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
+        \               \"properties\": {\n                    \"base_path\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
         \                   \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"base_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"private\": {\n                        \"type\": \"boolean\",\n
-        \                       \"description\": \"Restrict pull access to explicitly
-        authorized users. Defaults to unrestricted pull access.\"\n                    },\n
-        \                   \"description\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"An optional description.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"base_path\",\n                    \"name\"\n                ]\n
-        \           },\n            \"container.ContainerDistributionResponse\": {\n
-        \               \"type\": \"object\",\n                \"description\": \"A
-        serializer for ContainerDistribution.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"no_content_change_since\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp since when the
-        distributed content served by this distribution has not changed. If equals
-        to `null`, no guarantee is provided about content changes.\"\n                    },\n
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
         \                   \"content_guard\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
         \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"private\":
+        {\n                        \"type\": \"boolean\",\n                        \"description\":
+        \"Restrict pull access to explicitly authorized users. Defaults to unrestricted
+        pull access.\"\n                    },\n                    \"description\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"An optional description.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"base_path\",\n                    \"name\"\n
+        \               ]\n            },\n            \"container.ContainerDistributionResponse\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"A serializer for ContainerDistribution.\",\n                \"properties\":
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"base_path\": {\n                        \"type\":
+        \"string\",\n                        \"description\": \"The base (relative)
+        path component of the published url. Avoid paths that                     overlap
+        with other distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n
+        \                   },\n                    \"no_content_change_since\": {\n
+        \                       \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp since when the
+        distributed content served by this distribution has not changed. If equals
+        to `null`, no guarantee is provided about content changes.\"\n                    },\n
+        \                   \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
+        \                   \"content_guard_prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN) of the associated optional content guard.\"\n
+        \                   },\n                    \"hidden\": {\n                        \"type\":
+        \"boolean\",\n                        \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"pulp_last_updated\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
         true,\n                        \"description\": \"Timestamp of the last time
         this resource was updated. Note: for immutable resources - like content, repository
         versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"pulp_href\":
+        be the same.\"\n                    },\n                    \"content_guard\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"base_path\": {\n                        \"type\": \"string\",\n
-        \                       \"description\": \"The base (relative) path component
-        of the published url. Avoid paths that                     overlap with other
-        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
-        \                   \"pulp_created\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"repository\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"The latest RepositoryVersion
-        for this Repository will be served.\"\n                    },\n                    \"registry_path\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"A unique name. Ex, `rawhide` and
+        `stable`.\"\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"registry_path\":
         {\n                        \"type\": \"string\",\n                        \"readOnly\":
         true,\n                        \"description\": \"The Registry hostname/name/
         to use with docker pull command defined by this distribution.\"\n                    },\n
@@ -68645,34 +68941,34 @@ interactions:
         \                   \"name\"\n                ]\n            },\n            \"container.ContainerPullThroughDistribution\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
-        \               \"properties\": {\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"A unique name. Ex, `rawhide`
-        and `stable`.\"\n                    },\n                    \"hidden\": {\n
-        \                       \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"content_guard\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"An optional content-guard.
-        If none is specified, a default one will be used.\"\n                    },\n
+        \               \"properties\": {\n                    \"base_path\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"The base (relative) path component
+        of the published url. Avoid paths that                     overlap with other
+        distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
         \                   \"pulp_labels\": {\n                        \"type\":
         \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
         \"string\",\n                            \"nullable\": true\n                        }\n
-        \                   },\n                    \"base_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"The base (relative) path component of the published url. Avoid paths that
-        \                    overlap with other distribution base paths (e.g. \\\"foo\\\"
-        and \\\"foo/bar\\\")\"\n                    },\n                    \"repository\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
+        \                   },\n                    \"repository_version\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
+        true,\n                        \"description\": \"RepositoryVersion to be
+        served\"\n                    },\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
-        \                   \"remote\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Remote that can be used to fetch content when using pull-through caching.\"\n
-        \                   },\n                    \"distributions\": {\n                        \"type\":
+        \                   \"hidden\": {\n                        \"type\": \"boolean\",\n
+        \                       \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"content_guard\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
+        \"An optional content-guard. If none is specified, a default one will be used.\"\n
+        \                   },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"remote\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Remote that can be used
+        to fetch content when using pull-through caching.\"\n                    },\n
+        \                   \"distributions\": {\n                        \"type\":
         \"array\",\n                        \"items\": {\n                            \"type\":
         \"string\",\n                            \"format\": \"uri\"\n                        },\n
         \                       \"description\": \"Distributions created after pulling
@@ -68688,49 +68984,50 @@ interactions:
         \               ]\n            },\n            \"container.ContainerPullThroughDistributionResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A serializer for a specialized pull-through distribution referencing sub-distributions.\",\n
-        \               \"properties\": {\n                    \"prn\": {\n                        \"type\":
-        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"repository_version\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
-        \"RepositoryVersion to be served\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name. Ex, `rawhide` and `stable`.\"\n                    },\n                    \"hidden\":
-        {\n                        \"type\": \"boolean\",\n                        \"default\":
-        false,\n                        \"description\": \"Whether this distribution
-        should be shown in the content app.\"\n                    },\n                    \"no_content_change_since\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp since when the
-        distributed content served by this distribution has not changed. If equals
-        to `null`, no guarantee is provided about content changes.\"\n                    },\n
-        \                   \"content_guard\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"An optional content-guard. If none is specified, a default one will be used.\"\n
-        \                   },\n                    \"pulp_last_updated\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of the last time
-        this resource was updated. Note: for immutable resources - like content, repository
-        versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"content_guard_prn\":
-        {\n                        \"type\": \"string\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"The Pulp Resource Name (PRN)
-        of the associated optional content guard.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
+        \               \"properties\": {\n                    \"pulp_href\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"readOnly\": true\n                    },\n
         \                   \"base_path\": {\n                        \"type\": \"string\",\n
         \                       \"description\": \"The base (relative) path component
         of the published url. Avoid paths that                     overlap with other
         distribution base paths (e.g. \\\"foo\\\" and \\\"foo/bar\\\")\"\n                    },\n
-        \                   \"pulp_created\": {\n                        \"type\":
+        \                   \"no_content_change_since\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp since when the distributed content served by this distribution
+        has not changed. If equals to `null`, no guarantee is provided about content
+        changes.\"\n                    },\n                    \"pulp_created\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of creation.\"\n                    },\n                    \"pulp_labels\":
+        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        }\n                    },\n                    \"repository_version\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"RepositoryVersion to be served\"\n                    },\n                    \"repository\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"nullable\": true,\n                        \"description\":
+        \"The latest RepositoryVersion for this Repository will be served.\"\n                    },\n
+        \                   \"content_guard_prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN) of the associated optional content guard.\"\n
+        \                   },\n                    \"hidden\": {\n                        \"type\":
+        \"boolean\",\n                        \"default\": false,\n                        \"description\":
+        \"Whether this distribution should be shown in the content app.\"\n                    },\n
+        \                   \"pulp_last_updated\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
-        \                   },\n                    \"repository\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"nullable\":
-        true,\n                        \"description\": \"The latest RepositoryVersion
-        for this Repository will be served.\"\n                    },\n                    \"remote\":
+        true,\n                        \"description\": \"Timestamp of the last time
+        this resource was updated. Note: for immutable resources - like content, repository
+        versions, and publication - pulp_created and pulp_last_updated dates will
+        be the same.\"\n                    },\n                    \"content_guard\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"An optional content-guard.
+        If none is specified, a default one will be used.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"A unique name. Ex, `rawhide` and
+        `stable`.\"\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"remote\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"description\": \"Remote that can be used
         to fetch content when using pull-through caching.\"\n                    },\n
@@ -68950,68 +69247,69 @@ interactions:
         \               ]\n            },\n            \"container.ContainerPushRepository\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"A unique name for this repository.\"\n                    },\n                    \"retain_repo_versions\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
+        {\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"retain_checkpoints\": {\n                        \"type\":
+        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
+        true,\n                        \"description\": \"Retain X checkpoint publications
+        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
+        1\n                    },\n                    \"retain_repo_versions\": {\n
+        \                       \"type\": \"integer\",\n                        \"format\":
         \"int64\",\n                        \"nullable\": true,\n                        \"description\":
         \"Retain X versions of the repository. Default is null which retains all versions.\",\n
-        \                       \"minimum\": 1\n                    },\n                    \"manifest_signing_service\":
+        \                       \"minimum\": 1\n                    },\n                    \"name\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"A unique name for this repository.\"\n
+        \                   },\n                    \"manifest_signing_service\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"A reference to an associated signing service.\"\n                    },\n
         \                   \"description\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
         1,\n                        \"description\": \"An optional description.\"\n
-        \                   },\n                    \"retain_checkpoints\": {\n                        \"type\":
-        \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
-        true,\n                        \"description\": \"Retain X checkpoint publications
-        for the repository. Default is null which retains all checkpoints.\",\n                        \"minimum\":
-        1\n                    },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        }\n
         \                   }\n                },\n                \"required\": [\n
         \                   \"name\"\n                ]\n            },\n            \"container.ContainerPushRepositoryResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"Serializer for Container Push Repositories.\",\n                \"properties\":
-        {\n                    \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
-        \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"name\":
-        {\n                        \"type\": \"string\",\n                        \"description\":
-        \"A unique name for this repository.\"\n                    },\n                    \"latest_version_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        }\n
+        \                   },\n                    \"pulp_created\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \                   },\n                    \"latest_version_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"versions_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"retain_checkpoints\":
+        {\n                        \"type\": \"integer\",\n                        \"format\":
+        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
+        \"Retain X checkpoint publications for the repository. Default is null which
+        retains all checkpoints.\",\n                        \"minimum\": 1\n                    },\n
         \                   \"retain_repo_versions\": {\n                        \"type\":
         \"integer\",\n                        \"format\": \"int64\",\n                        \"nullable\":
         true,\n                        \"description\": \"Retain X versions of the
         repository. Default is null which retains all versions.\",\n                        \"minimum\":
-        1\n                    },\n                    \"manifest_signing_service\":
+        1\n                    },\n                    \"pulp_last_updated\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
+        \"Timestamp of the last time this resource was updated. Note: for immutable
+        resources - like content, repository versions, and publication - pulp_created
+        and pulp_last_updated dates will be the same.\"\n                    },\n
+        \                   \"name\": {\n                        \"type\": \"string\",\n
+        \                       \"description\": \"A unique name for this repository.\"\n
+        \                   },\n                    \"manifest_signing_service\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"nullable\": true,\n                        \"description\":
         \"A reference to an associated signing service.\"\n                    },\n
         \                   \"description\": {\n                        \"type\":
         \"string\",\n                        \"nullable\": true,\n                        \"description\":
-        \"An optional description.\"\n                    },\n                    \"retain_checkpoints\":
-        {\n                        \"type\": \"integer\",\n                        \"format\":
-        \"int64\",\n                        \"nullable\": true,\n                        \"description\":
-        \"Retain X checkpoint publications for the repository. Default is null which
-        retains all checkpoints.\",\n                        \"minimum\": 1\n                    },\n
-        \                   \"pulp_last_updated\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of the last time
-        this resource was updated. Note: for immutable resources - like content, repository
-        versions, and publication - pulp_created and pulp_last_updated dates will
-        be the same.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        }\n                    },\n                    \"pulp_href\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"versions_href\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
-        true\n                    },\n                    \"pulp_created\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"date-time\",\n                        \"readOnly\":
-        true,\n                        \"description\": \"Timestamp of creation.\"\n
+        \"An optional description.\"\n                    },\n                    \"prn\":
+        {\n                        \"type\": \"string\",\n                        \"readOnly\":
+        true,\n                        \"description\": \"The Pulp Resource Name (PRN).\"\n
         \                   }\n                },\n                \"required\": [\n
         \                   \"name\"\n                ]\n            },\n            \"container.ContainerRemote\":
         {\n                \"type\": \"object\",\n                \"description\":
@@ -70026,30 +70324,35 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70108,16 +70411,22 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
-        \                       \"description\": \"A dict mapping relative paths inside
-        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
-        \                   },\n                    \"component\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifacts\": {\n
+        \                       \"type\": \"object\",\n                        \"description\":
+        \"A dict mapping relative paths inside the Content to the correspondingArtifact
+        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
+        \                   \"component\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
         \"Component of the component - architecture combination.\"\n                    },\n
         \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
@@ -70169,30 +70478,35 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Path where the artifact is
-        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Path where the artifact is located relative to distributions base_path\"\n
+        \                   },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that may
+        be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
-        \                   \"upload\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uncommitted upload that
-        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
-        \                   \"downloader_config\": {\n                        \"allOf\":
-        [\n                            {\n                                \"$ref\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
+        \                   \"file_url\": {\n                        \"type\": \"string\",\n
+        \                       \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"A url that Pulp can download
+        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
+        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70299,29 +70613,35 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -70337,17 +70657,22 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifacts\": {\n
-        \                       \"type\": \"object\",\n                        \"description\":
-        \"A dict mapping relative paths inside the Content to the correspondingArtifact
-        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
-        \                   \"component\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
+        \                       \"description\": \"A dict mapping relative paths inside
+        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
+        \                   },\n                    \"component\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Component of the component - architecture combination.\"\n                    },\n
         \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
@@ -70397,26 +70722,31 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"package\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Package that is contained in release_comonent.\"\n                    },\n
-        \                   \"release_component\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
-        \"ReleaseComponent this package is contained in.\"\n                    }\n
-        \               },\n                \"required\": [\n                    \"package\",\n
-        \                   \"release_component\"\n                ]\n            },\n
-        \           \"deb.PackageReleaseComponentResponse\": {\n                \"type\":
-        \"object\",\n                \"description\": \"A Serializer for PackageReleaseComponent.\",\n
-        \               \"properties\": {\n                    \"pulp_href\": {\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"package\": {\n
         \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"readOnly\": true\n                    },\n
-        \                   \"prn\": {\n                        \"type\": \"string\",\n
-        \                       \"readOnly\": true,\n                        \"description\":
+        \"uri\",\n                        \"description\": \"Package that is contained
+        in release_comonent.\"\n                    },\n                    \"release_component\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"ReleaseComponent this
+        package is contained in.\"\n                    }\n                },\n                \"required\":
+        [\n                    \"package\",\n                    \"release_component\"\n
+        \               ]\n            },\n            \"deb.PackageReleaseComponentResponse\":
+        {\n                \"type\": \"object\",\n                \"description\":
+        \"A Serializer for PackageReleaseComponent.\",\n                \"properties\":
+        {\n                    \"pulp_href\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"uri\",\n                        \"readOnly\":
+        true\n                    },\n                    \"prn\": {\n                        \"type\":
+        \"string\",\n                        \"readOnly\": true,\n                        \"description\":
         \"The Pulp Resource Name (PRN).\"\n                    },\n                    \"pulp_created\":
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"date-time\",\n                        \"readOnly\": true,\n                        \"description\":
@@ -70546,15 +70876,21 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"codename\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    },\n                    \"suite\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1\n                    },\n                    \"distribution\": {\n                        \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"codename\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1\n                    },\n                    \"suite\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    },\n
+        \                   \"distribution\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1\n                    },\n
         \                   \"version\": {\n                        \"type\": \"string\",\n
         \                       \"nullable\": true,\n                        \"minLength\":
@@ -70578,18 +70914,24 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"architecture\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Name of the architecture.\"\n
-        \                   },\n                    \"distribution\": {\n                        \"type\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"architecture\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Name of the distribution.\"\n                    }\n                },\n
-        \               \"required\": [\n                    \"architecture\",\n                    \"distribution\"\n
+        \"Name of the architecture.\"\n                    },\n                    \"distribution\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Name of the distribution.\"\n
+        \                   }\n                },\n                \"required\": [\n
+        \                   \"architecture\",\n                    \"distribution\"\n
         \               ]\n            },\n            \"deb.ReleaseArchitectureResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ReleaseArchitecture.\",\n                \"properties\":
@@ -70625,18 +70967,23 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"component\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"Name of the component.\"\n                    },\n                    \"distribution\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Name of the distribution.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"component\",\n                    \"distribution\"\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"component\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Name of the component.\"\n
+        \                   },\n                    \"distribution\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Name of the distribution.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"component\",\n                    \"distribution\"\n
         \               ]\n            },\n            \"deb.ReleaseComponentResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for ReleaseComponent.\",\n                \"properties\": {\n
@@ -70674,17 +71021,22 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifacts\": {\n
-        \                       \"type\": \"object\",\n                        \"description\":
-        \"A dict mapping relative paths inside the Content to the correspondingArtifact
-        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
-        \                   \"codename\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
+        \                       \"description\": \"A dict mapping relative paths inside
+        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
+        \                   },\n                    \"codename\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Codename of the release, e.g. \\\"buster\\\".\"\n                    },\n
         \                   \"suite\": {\n                        \"type\": \"string\",\n
         \                       \"minLength\": 1,\n                        \"description\":
@@ -70780,16 +71132,22 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifacts\": {\n                        \"type\": \"object\",\n
-        \                       \"description\": \"A dict mapping relative paths inside
-        the Content to the correspondingArtifact URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n
-        \                   },\n                    \"release\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifacts\": {\n
+        \                       \"type\": \"object\",\n                        \"description\":
+        \"A dict mapping relative paths inside the Content to the correspondingArtifact
+        URLs. E.g.: {'relative/path': '/artifacts/1/'\"\n                    },\n
+        \                   \"release\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
         \"Release this index file belongs to.\"\n                    },\n                    \"component\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Component this index file belongs
@@ -70839,27 +71197,38 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"Artifact URL of the Debian
-        Source Control (dsc) file.\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Relative path of the Debian
-        Source Control (dsc) file.It is normally advised to let Pulp generate this.\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"artifact\"\n                ]\n            },\n            \"deb.SourcePackageReleaseComponent\":
-        {\n                \"type\": \"object\",\n                \"description\":
-        \"A Serializer for SourcePackageReleaseComponent.\",\n                \"properties\":
-        {\n                    \"repository\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"Artifact URL of the Debian Source Control (dsc) file.\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"Relative path of the Debian Source Control (dsc) file.It is normally advised
+        to let Pulp generate this.\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"artifact\"\n                ]\n
+        \           },\n            \"deb.SourcePackageReleaseComponent\": {\n                \"type\":
+        \"object\",\n                \"description\": \"A Serializer for SourcePackageReleaseComponent.\",\n
+        \               \"properties\": {\n                    \"repository\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"A URI of a repository the new content unit should be associated with.\"\n
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
         {\n                            \"type\": \"string\",\n                            \"nullable\":
         true\n                        },\n                        \"description\":
         \"A dictionary of arbitrary key/value pairs used to describe a specific Content
@@ -71066,29 +71435,35 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -71716,19 +72091,25 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"file\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uploaded file that should be turned into the artifact of the content
-        unit.\"\n                    }\n                }\n            },\n            \"gem.GemContentResponse\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"file\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uploaded file that should
+        be turned into the artifact of the content unit.\"\n                    }\n
+        \               }\n            },\n            \"gem.GemContentResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for GemContent.\",\n                \"properties\": {\n                    \"pulp_href\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -72175,19 +72556,24 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
+        \"The relative path within the repository\"\n                    },\n                    \"repo_id\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"The relative path within the
-        repository\"\n                    },\n                    \"repo_id\": {\n
-        \                       \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"The Hugging Face repository
         ID (e.g., 'microsoft/DialoGPT-medium')\"\n                    },\n                    \"repo_type\":
         {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
@@ -72669,20 +73055,25 @@ interactions:
         \                   \"repository\": {\n                        \"type\": \"string\",\n
         \                       \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
-        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
-        true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   }\n                },\n                \"required\": [\n
-        \                   \"artifact\",\n                    \"relative_path\"\n
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    }\n                },\n
+        \               \"required\": [\n                    \"artifact\",\n                    \"relative_path\"\n
         \               ]\n            },\n            \"maven.MavenArtifactResponse\":
         {\n                \"type\": \"object\",\n                \"description\":
         \"A Serializer for MavenArtifact.\",\n                \"properties\": {\n
@@ -73415,30 +73806,36 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path.
-        If not provided, it will be computed from name and version.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path. If not provided, it will be computed
+        from name and version.\"\n                    },\n                    \"file\":
         {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
+        {\n                        \"type\": \"string\",\n                        \"writeOnly\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -73557,21 +73954,26 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"artifact\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"uri\",\n                        \"description\":
-        \"Artifact file representing the physical content\"\n                    },\n
-        \                   \"relative_path\": {\n                        \"type\":
-        \"string\",\n                        \"minLength\": 1\n                    },\n
-        \                   \"digest\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1\n                    }\n                },\n
-        \               \"required\": [\n                    \"artifact\",\n                    \"digest\",\n
-        \                   \"relative_path\"\n                ]\n            },\n
-        \           \"ostree.OstreeContentResponse\": {\n                \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"artifact\": {\n
+        \                       \"type\": \"string\",\n                        \"format\":
+        \"uri\",\n                        \"description\": \"Artifact file representing
+        the physical content\"\n                    },\n                    \"relative_path\":
+        {\n                        \"type\": \"string\",\n                        \"minLength\":
+        1\n                    },\n                    \"digest\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1\n                    }\n
+        \               },\n                \"required\": [\n                    \"artifact\",\n
+        \                   \"digest\",\n                    \"relative_path\"\n                ]\n
+        \           },\n            \"ostree.OstreeContentResponse\": {\n                \"type\":
         \"object\",\n                \"description\": \"A Serializer class for uncategorized
         content units (e.g., static deltas).\",\n                \"properties\": {\n
         \                   \"pulp_href\": {\n                        \"type\": \"string\",\n
@@ -74074,13 +74476,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -74285,30 +74692,36 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -74953,13 +75366,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"name\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"name\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Modulemd name.\"\n                    },\n                    \"stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Stream name.\"\n                    },\n
@@ -74999,13 +75417,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"module\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"module\": {\n                        \"type\":
+        \"string\",\n                        \"minLength\": 1,\n                        \"description\":
         \"Modulemd name.\"\n                    },\n                    \"stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
         1,\n                        \"description\": \"Modulemd default stream.\"\n
@@ -75052,34 +75475,39 @@ interactions:
         {\n                        \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"modified\": {\n                        \"type\": \"string\",\n
-        \                       \"minLength\": 1,\n                        \"description\":
-        \"Obsolete modified time.\"\n                    },\n                    \"module_name\":
-        {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Modulemd name.\"\n                    },\n
-        \                   \"module_stream\": {\n                        \"type\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"modified\": {\n
+        \                       \"type\": \"string\",\n                        \"minLength\":
+        1,\n                        \"description\": \"Obsolete modified time.\"\n
+        \                   },\n                    \"module_name\": {\n                        \"type\":
         \"string\",\n                        \"minLength\": 1,\n                        \"description\":
-        \"Modulemd's stream.\"\n                    },\n                    \"message\":
+        \"Modulemd name.\"\n                    },\n                    \"module_stream\":
         {\n                        \"type\": \"string\",\n                        \"minLength\":
-        1,\n                        \"description\": \"Obsolete description.\"\n                    },\n
-        \                   \"override_previous\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Reset previous obsoletes.\"\n
-        \                   },\n                    \"module_context\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Modulemd's context.\"\n                    },\n
-        \                   \"eol_date\": {\n                        \"type\": \"string\",\n
-        \                       \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"End of Life date.\"\n                    },\n
-        \                   \"obsoleted_by_module_name\": {\n                        \"type\":
-        \"string\",\n                        \"nullable\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"Obsolete by module name.\"\n
-        \                   },\n                    \"obsoleted_by_module_stream\":
+        1,\n                        \"description\": \"Modulemd's stream.\"\n                    },\n
+        \                   \"message\": {\n                        \"type\": \"string\",\n
+        \                       \"minLength\": 1,\n                        \"description\":
+        \"Obsolete description.\"\n                    },\n                    \"override_previous\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Reset previous obsoletes.\"\n                    },\n                    \"module_context\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Modulemd's context.\"\n                    },\n                    \"eol_date\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"End of Life date.\"\n                    },\n                    \"obsoleted_by_module_name\":
+        {\n                        \"type\": \"string\",\n                        \"nullable\":
+        true,\n                        \"minLength\": 1,\n                        \"description\":
+        \"Obsolete by module name.\"\n                    },\n                    \"obsoleted_by_module_stream\":
         {\n                        \"type\": \"string\",\n                        \"nullable\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
         \"Obsolete by module stream.\"\n                    },\n                    \"snippet\":
@@ -75199,30 +75627,36 @@ interactions:
         {\n                    \"repository\": {\n                        \"type\":
         \"string\",\n                        \"format\": \"uri\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"A URI of a repository the
-        new content unit should be associated with.\"\n                    },\n                    \"pulp_labels\":
-        {\n                        \"type\": \"object\",\n                        \"additionalProperties\":
-        {\n                            \"type\": \"string\",\n                            \"nullable\":
-        true\n                        },\n                        \"description\":
-        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
-        instance.\"\n                    },\n                    \"artifact\": {\n
-        \                       \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"description\": \"Artifact file representing
-        the physical content\"\n                    },\n                    \"relative_path\":
+        new content unit should be associated with.\"\n                    },\n                    \"overwrite\":
+        {\n                        \"type\": \"boolean\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"When set to true, existing
+        content in the repository with the same unique key will be silently overwritten.
+        When set to false, the task will fail if content would be overwritten. Only
+        used when 'repository' is specified. Defaults to true.\"\n                    },\n
+        \                   \"pulp_labels\": {\n                        \"type\":
+        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
+        \"string\",\n                            \"nullable\": true\n                        },\n
+        \                       \"description\": \"A dictionary of arbitrary key/value
+        pairs used to describe a specific Content instance.\"\n                    },\n
+        \                   \"artifact\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"description\":
+        \"Artifact file representing the physical content\"\n                    },\n
+        \                   \"relative_path\": {\n                        \"type\":
+        \"string\",\n                        \"writeOnly\": true,\n                        \"minLength\":
+        1,\n                        \"description\": \"Path where the artifact is
+        located relative to distributions base_path\"\n                    },\n                    \"file\":
+        {\n                        \"type\": \"string\",\n                        \"format\":
+        \"binary\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"An uploaded file that may be turned into the content unit.\"\n                    },\n
+        \                   \"upload\": {\n                        \"type\": \"string\",\n
+        \                       \"format\": \"uri\",\n                        \"writeOnly\":
+        true,\n                        \"description\": \"An uncommitted upload that
+        may be turned into the content unit.\"\n                    },\n                    \"file_url\":
         {\n                        \"type\": \"string\",\n                        \"writeOnly\":
         true,\n                        \"minLength\": 1,\n                        \"description\":
-        \"Path where the artifact is located relative to distributions base_path\"\n
-        \                   },\n                    \"file\": {\n                        \"type\":
-        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
-        true,\n                        \"description\": \"An uploaded file that may
-        be turned into the content unit.\"\n                    },\n                    \"upload\":
-        {\n                        \"type\": \"string\",\n                        \"format\":
-        \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
-        \"An uncommitted upload that may be turned into the content unit.\"\n                    },\n
-        \                   \"file_url\": {\n                        \"type\": \"string\",\n
-        \                       \"writeOnly\": true,\n                        \"minLength\":
-        1,\n                        \"description\": \"A url that Pulp can download
-        and turn into the content unit.\"\n                    },\n                    \"downloader_config\":
-        {\n                        \"allOf\": [\n                            {\n                                \"$ref\":
+        \"A url that Pulp can download and turn into the content unit.\"\n                    },\n
+        \                   \"downloader_config\": {\n                        \"allOf\":
+        [\n                            {\n                                \"$ref\":
         \"#/components/schemas/RemoteNetworkConfig\"\n                            }\n
         \                       ],\n                        \"writeOnly\": true,\n
         \                       \"description\": \"Configuration for the download
@@ -76471,13 +76905,18 @@ interactions:
         \                       \"type\": \"string\",\n                        \"format\":
         \"uri\",\n                        \"writeOnly\": true,\n                        \"description\":
         \"A URI of a repository the new content unit should be associated with.\"\n
-        \                   },\n                    \"pulp_labels\": {\n                        \"type\":
-        \"object\",\n                        \"additionalProperties\": {\n                            \"type\":
-        \"string\",\n                            \"nullable\": true\n                        },\n
-        \                       \"description\": \"A dictionary of arbitrary key/value
-        pairs used to describe a specific Content instance.\"\n                    },\n
-        \                   \"file\": {\n                        \"type\": \"string\",\n
-        \                       \"format\": \"binary\",\n                        \"writeOnly\":
+        \                   },\n                    \"overwrite\": {\n                        \"type\":
+        \"boolean\",\n                        \"writeOnly\": true,\n                        \"description\":
+        \"When set to true, existing content in the repository with the same unique
+        key will be silently overwritten. When set to false, the task will fail if
+        content would be overwritten. Only used when 'repository' is specified. Defaults
+        to true.\"\n                    },\n                    \"pulp_labels\": {\n
+        \                       \"type\": \"object\",\n                        \"additionalProperties\":
+        {\n                            \"type\": \"string\",\n                            \"nullable\":
+        true\n                        },\n                        \"description\":
+        \"A dictionary of arbitrary key/value pairs used to describe a specific Content
+        instance.\"\n                    },\n                    \"file\": {\n                        \"type\":
+        \"string\",\n                        \"format\": \"binary\",\n                        \"writeOnly\":
         true,\n                        \"description\": \"An uploaded file that may
         be turned into the content unit.\"\n                    },\n                    \"upload\":
         {\n                        \"type\": \"string\",\n                        \"format\":
@@ -76576,7 +77015,7 @@ interactions:
       Access-Control-Expose-Headers:
       - Correlation-ID
       Age:
-      - '1'
+      - '2'
       Allow:
       - GET, HEAD, OPTIONS
       Cache-Control:
@@ -76586,17 +77025,17 @@ interactions:
       Content-Disposition:
       - inline; filename="Pulp 3 API.json"
       Content-Length:
-      - '6376034'
+      - '6411073'
       Content-Type:
       - application/json
       Correlation-ID:
-      - f1fc2641fbcb43398c298c89159d9c7f
+      - 92e31052c5b4438aa7cabcbc52c45634
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:35 GMT
+      - Mon, 18 May 2026 18:53:51 GMT
       Expires:
-      - Sun, 16 Aug 2026 20:57:34 GMT
+      - Wed, 26 Aug 2026 18:53:49 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -76613,23 +77052,29 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - f1fc2641fbcb43398c298c89159d9c7f
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 92e31052c5b4438aa7cabcbc52c45634
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/remotes/rpm/rpm/?name=test_rpm_remote&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","prn":"prn:rpm.rpmremote:019e0961-a71e-77a3-a7f9-76461d5b1a16","pulp_created":"2026-05-08T20:57:35.263060Z","pulp_last_updated":"2026-05-08T20:57:35.263072Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","pulp_labels":{},"policy":"immediate","hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"max_retries":null,"total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"download_concurrency":null,"rate_limit":null,"sles_auth_token":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","prn":"prn:rpm.rpmremote:019e3c6f-f509-7ded-9cdf-7fccb2ab36f8","pulp_created":"2026-05-18T18:53:50.730584Z","pulp_last_updated":"2026-05-18T18:53:50.730595Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","pulp_labels":{},"policy":"immediate","hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"max_retries":null,"total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"download_concurrency":null,"rate_limit":null,"sles_auth_token":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -76642,11 +77087,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f1fc2641fbcb43398c298c89159d9c7f
+      - 92e31052c5b4438aa7cabcbc52c45634
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:36 GMT
+      - Mon, 18 May 2026 18:53:51 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-1.yml
+++ b/tests/fixtures/rpm_repository-1.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/remotes/rpm/rpm/?name=test_rpm_remote&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","prn":"prn:rpm.rpmremote:019e0961-a71e-77a3-a7f9-76461d5b1a16","pulp_created":"2026-05-08T20:57:35.263060Z","pulp_last_updated":"2026-05-08T20:57:35.263072Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","pulp_labels":{},"policy":"immediate","hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"max_retries":null,"total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"download_concurrency":null,"rate_limit":null,"sles_auth_token":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","prn":"prn:rpm.rpmremote:019e3c6f-f509-7ded-9cdf-7fccb2ab36f8","pulp_created":"2026-05-18T18:53:50.730584Z","pulp_last_updated":"2026-05-18T18:53:50.730595Z","name":"test_rpm_remote","url":"https://fixtures.pulpproject.org/rpm-signed/","pulp_labels":{},"policy":"immediate","hidden_fields":[{"name":"client_key","is_set":false},{"name":"proxy_username","is_set":false},{"name":"proxy_password","is_set":false},{"name":"username","is_set":false},{"name":"password","is_set":false}],"ca_cert":null,"client_cert":null,"tls_validation":true,"proxy_url":null,"max_retries":null,"total_timeout":null,"connect_timeout":null,"sock_connect_timeout":null,"sock_read_timeout":null,"headers":null,"download_concurrency":null,"rate_limit":null,"sles_auth_token":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 44e726b156b84d7297c501d06e2e0d8e
+      - 7660d4b33f7e40a0a24f5730f70da8ff
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:36 GMT
+      - Mon, 18 May 2026 18:53:52 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -50,17 +56,23 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 44e726b156b84d7297c501d06e2e0d8e
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 7660d4b33f7e40a0a24f5730f70da8ff
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
@@ -79,11 +91,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 44e726b156b84d7297c501d06e2e0d8e
+      - 7660d4b33f7e40a0a24f5730f70da8ff
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:36 GMT
+      - Mon, 18 May 2026 18:53:52 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -98,22 +110,28 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"remote": "/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/",
+    body: '{"remote": "/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/",
       "description": null, "name": "test_rpm_repository"}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '132'
       Correlation-Id:
-      - 44e726b156b84d7297c501d06e2e0d8e
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 7660d4b33f7e40a0a24f5730f70da8ff
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
@@ -121,7 +139,7 @@ interactions:
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:37.030664Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:52.394768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -134,13 +152,13 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 44e726b156b84d7297c501d06e2e0d8e
+      - 7660d4b33f7e40a0a24f5730f70da8ff
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:37 GMT
+      - Mon, 18 May 2026 18:53:52 GMT
       Location:
-      - /pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+      - /pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-10.yml
+++ b/tests/fixtures/rpm_repository-10.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:42.067388Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:57.599641Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 74aa059ace514d7692fbd27e7e7d7a37
+      - 75baa4424d624fe79dd6aa3f2bbeca56
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:42 GMT
+      - Mon, 18 May 2026 18:53:58 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-11.yml
+++ b/tests/fixtures/rpm_repository-11.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:42.067388Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:57.599641Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e148dc2658c04e6297a25e7afe54c52d
+      - 66ea77166a694924beda153621f1211a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:43 GMT
+      - Mon, 18 May 2026 18:53:58 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"retain_package_versions": 0}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '30'
       Correlation-Id:
-      - e148dc2658c04e6297a25e7afe54c52d
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 66ea77166a694924beda153621f1211a
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-c6ce-76d7-9add-374b60c75952/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-1520-7423-bbb0-fb387e19853f/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e148dc2658c04e6297a25e7afe54c52d
+      - 66ea77166a694924beda153621f1211a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:43 GMT
+      - Mon, 18 May 2026 18:53:58 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - e148dc2658c04e6297a25e7afe54c52d
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 66ea77166a694924beda153621f1211a
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-c6ce-76d7-9add-374b60c75952/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-1520-7423-bbb0-fb387e19853f/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-c6ce-76d7-9add-374b60c75952/","prn":"prn:core.task:019e0961-c6ce-76d7-9add-374b60c75952","pulp_created":"2026-05-08T20:57:43.377303Z","pulp_last_updated":"2026-05-08T20:57:43.375138Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"e148dc2658c04e6297a25e7afe54c52d","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:43.386617Z","started_at":"2026-05-08T20:57:43.389625Z","finished_at":"2026-05-08T20:57:43.397009Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:43.393350Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-1520-7423-bbb0-fb387e19853f/","prn":"prn:core.task:019e3c70-1520-7423-bbb0-fb387e19853f","pulp_created":"2026-05-18T18:53:58.946505Z","pulp_last_updated":"2026-05-18T18:53:58.944776Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"66ea77166a694924beda153621f1211a","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:53:58.953995Z","started_at":"2026-05-18T18:53:58.957739Z","finished_at":"2026-05-18T18:53:58.966554Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:53:58.961768Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e148dc2658c04e6297a25e7afe54c52d
+      - 66ea77166a694924beda153621f1211a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:43 GMT
+      - Mon, 18 May 2026 18:53:59 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - e148dc2658c04e6297a25e7afe54c52d
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 66ea77166a694924beda153621f1211a
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:43.393350Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:58.961768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e148dc2658c04e6297a25e7afe54c52d
+      - 66ea77166a694924beda153621f1211a
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:43 GMT
+      - Mon, 18 May 2026 18:53:59 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-12.yml
+++ b/tests/fixtures/rpm_repository-12.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:43.393350Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:58.961768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 23a3dc49a830490ebbc91d249d52cb2c
+      - 956b9cad13734dc6b3bfb44cc0bb7bea
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:44 GMT
+      - Mon, 18 May 2026 18:53:59 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-13.yml
+++ b/tests/fixtures/rpm_repository-13.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:43.393350Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:58.961768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:44 GMT
+      - Mon, 18 May 2026 18:54:00 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"retain_repo_versions": 5}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '27'
       Correlation-Id:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-cbfe-7967-a5d9-34aa4bb26570/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-1a63-75c0-a044-64bb0bea6919/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:44 GMT
+      - Mon, 18 May 2026 18:54:00 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-cbfe-7967-a5d9-34aa4bb26570/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-1a63-75c0-a044-64bb0bea6919/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-cbfe-7967-a5d9-34aa4bb26570/","prn":"prn:core.task:019e0961-cbfe-7967-a5d9-34aa4bb26570","pulp_created":"2026-05-08T20:57:44.704150Z","pulp_last_updated":"2026-05-08T20:57:44.702353Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"f9204d82bdeb4d20a79a7ae891f22cfc","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:44.712062Z","started_at":"2026-05-08T20:57:44.715828Z","finished_at":"2026-05-08T20:57:44.727105Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:44.719593Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-1a63-75c0-a044-64bb0bea6919/","prn":"prn:core.task:019e3c70-1a63-75c0-a044-64bb0bea6919","pulp_created":"2026-05-18T18:54:00.292845Z","pulp_last_updated":"2026-05-18T18:54:00.291499Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"0e5ebb38fc1d44c3b8cd47ae30e64eec","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:54:00.299387Z","started_at":"2026-05-18T18:54:00.303611Z","finished_at":"2026-05-18T18:54:00.315424Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:54:00.307439Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:44 GMT
+      - Mon, 18 May 2026 18:54:00 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:44.719593Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:00.307439Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9204d82bdeb4d20a79a7ae891f22cfc
+      - 0e5ebb38fc1d44c3b8cd47ae30e64eec
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:44 GMT
+      - Mon, 18 May 2026 18:54:00 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-14.yml
+++ b/tests/fixtures/rpm_repository-14.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:44.719593Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:00.307439Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - eb630703e9fa49f99c9d3283c1caead6
+      - c3a4fc70ca2543dc80b13226bb9de27e
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:45 GMT
+      - Mon, 18 May 2026 18:54:01 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-15.yml
+++ b/tests/fixtures/rpm_repository-15.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:44.719593Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:00.307439Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7917ee8b1087414cac08bad5129e3727
+      - ee0190ef3a7f464dabdda534a9d5c84b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:45 GMT
+      - Mon, 18 May 2026 18:54:01 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"pulp_labels": {"test_label": "1"}}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '36'
       Correlation-Id:
-      - 7917ee8b1087414cac08bad5129e3727
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - ee0190ef3a7f464dabdda534a9d5c84b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-d136-7d50-b2f0-c56715cffe9d/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-1fc6-7768-963d-cd070df8a027/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7917ee8b1087414cac08bad5129e3727
+      - ee0190ef3a7f464dabdda534a9d5c84b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:46 GMT
+      - Mon, 18 May 2026 18:54:01 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 7917ee8b1087414cac08bad5129e3727
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - ee0190ef3a7f464dabdda534a9d5c84b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-d136-7d50-b2f0-c56715cffe9d/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-1fc6-7768-963d-cd070df8a027/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-d136-7d50-b2f0-c56715cffe9d/","prn":"prn:core.task:019e0961-d136-7d50-b2f0-c56715cffe9d","pulp_created":"2026-05-08T20:57:46.040028Z","pulp_last_updated":"2026-05-08T20:57:46.038635Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"7917ee8b1087414cac08bad5129e3727","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:46.048332Z","started_at":"2026-05-08T20:57:46.054001Z","finished_at":"2026-05-08T20:57:46.062137Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:46.058112Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-1fc6-7768-963d-cd070df8a027/","prn":"prn:core.task:019e3c70-1fc6-7768-963d-cd070df8a027","pulp_created":"2026-05-18T18:54:01.673052Z","pulp_last_updated":"2026-05-18T18:54:01.670819Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"ee0190ef3a7f464dabdda534a9d5c84b","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:54:01.680685Z","started_at":"2026-05-18T18:54:01.684143Z","finished_at":"2026-05-18T18:54:01.693527Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:54:01.688124Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7917ee8b1087414cac08bad5129e3727
+      - ee0190ef3a7f464dabdda534a9d5c84b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:46 GMT
+      - Mon, 18 May 2026 18:54:01 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 7917ee8b1087414cac08bad5129e3727
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - ee0190ef3a7f464dabdda534a9d5c84b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 7917ee8b1087414cac08bad5129e3727
+      - ee0190ef3a7f464dabdda534a9d5c84b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:46 GMT
+      - Mon, 18 May 2026 18:54:01 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-16.yml
+++ b/tests/fixtures/rpm_repository-16.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 08becb41243a465a9306f69e6caf3e3d
+      - d990ab1db5b84afe826433d7924b23fa
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:46 GMT
+      - Mon, 18 May 2026 18:54:02 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-17.yml
+++ b/tests/fixtures/rpm_repository-17.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - ea2e7bc589e446c4a990abfc15d16fae
+      - 414b75c9fc5b42beaa36e89715acfce8
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:47 GMT
+      - Mon, 18 May 2026 18:54:02 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-18.yml
+++ b/tests/fixtures/rpm_repository-18.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?offset=0&limit=1000
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 097109af791c435081faa7d7d010717e
+      - c7a789eb003f48b9b6e4e4907ffc99d4
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:47 GMT
+      - Mon, 18 May 2026 18:54:03 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-19.yml
+++ b/tests/fixtures/rpm_repository-19.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e8cb6a9ba96b4f89b0fb08973839f141
+      - 88f98d1148414f09a079b2f25e3bede8
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:48 GMT
+      - Mon, 18 May 2026 18:54:03 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-2.yml
+++ b/tests/fixtures/rpm_repository-2.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:37.030664Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:52.394768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 3d03774ef2284e5e836e77aa93694f1a
+      - b94b764ac33c4c619c2e6c9f15183c45
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:37 GMT
+      - Mon, 18 May 2026 18:53:52 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-20.yml
+++ b/tests/fixtures/rpm_repository-20.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:46.058112Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:01.688124Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
+      - c84c7d2ae1bc4c16b82d609d7e93c108
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:48 GMT
+      - Mon, 18 May 2026 18:54:04 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"description": null}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '21'
       Correlation-Id:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - c84c7d2ae1bc4c16b82d609d7e93c108
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-dbfc-773c-ac2b-712ee1086df0/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-2a82-78e9-9edd-e543870b9e25/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
+      - c84c7d2ae1bc4c16b82d609d7e93c108
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:48 GMT
+      - Mon, 18 May 2026 18:54:04 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,23 +117,29 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - c84c7d2ae1bc4c16b82d609d7e93c108
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-dbfc-773c-ac2b-712ee1086df0/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-2a82-78e9-9edd-e543870b9e25/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-dbfc-773c-ac2b-712ee1086df0/","prn":"prn:core.task:019e0961-dbfc-773c-ac2b-712ee1086df0","pulp_created":"2026-05-08T20:57:48.798746Z","pulp_last_updated":"2026-05-08T20:57:48.796825Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"f9ce84eb0d7d4023a71dc4c38a0dd964","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:48.808086Z","started_at":"2026-05-08T20:57:48.811331Z","finished_at":"2026-05-08T20:57:48.819109Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":null,"pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:48.814794Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-2a82-78e9-9edd-e543870b9e25/","prn":"prn:core.task:019e3c70-2a82-78e9-9edd-e543870b9e25","pulp_created":"2026-05-18T18:54:04.420979Z","pulp_last_updated":"2026-05-18T18:54:04.419087Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"c84c7d2ae1bc4c16b82d609d7e93c108","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:54:04.427640Z","started_at":"2026-05-18T18:54:04.430715Z","finished_at":"2026-05-18T18:54:04.440179Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":null,"pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:54:04.435993Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -134,11 +152,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
+      - c84c7d2ae1bc4c16b82d609d7e93c108
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:48 GMT
+      - Mon, 18 May 2026 18:54:04 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -155,23 +173,29 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - c84c7d2ae1bc4c16b82d609d7e93c108
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:48.814794Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:04.435993Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -184,11 +208,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f9ce84eb0d7d4023a71dc4c38a0dd964
+      - c84c7d2ae1bc4c16b82d609d7e93c108
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:49 GMT
+      - Mon, 18 May 2026 18:54:04 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-21.yml
+++ b/tests/fixtures/rpm_repository-21.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:48.814794Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:04.435993Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f4d4d76c662d423dba9e07777acecc9e
+      - 09ec5365fcd1446192a7e88eeec74a6b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:49 GMT
+      - Mon, 18 May 2026 18:54:05 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-22.yml
+++ b/tests/fixtures/rpm_repository-22.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:48.814794Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:04.435993Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 212a8fe08b784aebafb4369afbcbf791
+      - 2d6aa3e2f3fd496590feba7e13275e8b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:50 GMT
+      - Mon, 18 May 2026 18:54:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -50,27 +56,33 @@ interactions:
 - request:
     body: '{"autopublish": false}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '22'
       Correlation-Id:
-      - 212a8fe08b784aebafb4369afbcbf791
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 2d6aa3e2f3fd496590feba7e13275e8b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-e146-7209-8ba2-d5f2fff936fa/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-2fb6-766a-a1eb-cb9236aad3e1/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -83,11 +95,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 212a8fe08b784aebafb4369afbcbf791
+      - 2d6aa3e2f3fd496590feba7e13275e8b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:50 GMT
+      - Mon, 18 May 2026 18:54:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -104,23 +116,29 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 212a8fe08b784aebafb4369afbcbf791
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 2d6aa3e2f3fd496590feba7e13275e8b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-e146-7209-8ba2-d5f2fff936fa/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-2fb6-766a-a1eb-cb9236aad3e1/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-e146-7209-8ba2-d5f2fff936fa/","prn":"prn:core.task:019e0961-e146-7209-8ba2-d5f2fff936fa","pulp_created":"2026-05-08T20:57:50.153177Z","pulp_last_updated":"2026-05-08T20:57:50.151313Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"212a8fe08b784aebafb4369afbcbf791","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:50.161491Z","started_at":"2026-05-08T20:57:50.165531Z","finished_at":"2026-05-08T20:57:50.173720Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":false,"description":null,"pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:50.169804Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-2fb6-766a-a1eb-cb9236aad3e1/","prn":"prn:core.task:019e3c70-2fb6-766a-a1eb-cb9236aad3e1","pulp_created":"2026-05-18T18:54:05.753052Z","pulp_last_updated":"2026-05-18T18:54:05.751005Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"2d6aa3e2f3fd496590feba7e13275e8b","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:54:05.760284Z","started_at":"2026-05-18T18:54:05.764061Z","finished_at":"2026-05-18T18:54:05.774790Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":false,"description":null,"pulp_labels":{"test_label":"1"},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:54:05.769492Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":5,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -133,11 +151,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 212a8fe08b784aebafb4369afbcbf791
+      - 2d6aa3e2f3fd496590feba7e13275e8b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:50 GMT
+      - Mon, 18 May 2026 18:54:05 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -154,23 +172,29 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 212a8fe08b784aebafb4369afbcbf791
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 2d6aa3e2f3fd496590feba7e13275e8b
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:50.169804Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:05.769492Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -183,11 +207,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 212a8fe08b784aebafb4369afbcbf791
+      - 2d6aa3e2f3fd496590feba7e13275e8b
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:50 GMT
+      - Mon, 18 May 2026 18:54:06 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-23.yml
+++ b/tests/fixtures/rpm_repository-23.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:50.169804Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:54:05.769492Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{"test_label":"1"},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":5,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d16c07c6f9bd48a386e9a43533350799
+      - b19cc5ead41845c992190c0b754ba540
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:50 GMT
+      - Mon, 18 May 2026 18:54:06 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-25.yml
+++ b/tests/fixtures/rpm_repository-25.yml
@@ -2,15 +2,21 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 8807a42021954347b52d331845146c7c
+      - 69de5fe4fb804d8b8d3949f864008cad
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:52 GMT
+      - Mon, 18 May 2026 18:54:07 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-3.yml
+++ b/tests/fixtures/rpm_repository-3.yml
@@ -2,21 +2,27 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:37.030664Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:52.394768Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":null,"retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -29,11 +35,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 66610adf58884e068ac7eb8c886d7368
+      - 3723f4e6c2d84dbaa095e4ed6310824c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:37 GMT
+      - Mon, 18 May 2026 18:53:53 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -50,27 +56,33 @@ interactions:
 - request:
     body: '{"description": "repository created via ansible"}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '49'
       Correlation-Id:
-      - 66610adf58884e068ac7eb8c886d7368
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 3723f4e6c2d84dbaa095e4ed6310824c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-b213-77a5-a080-beec79693f2c/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-003c-7404-b425-5ac7eb5be8bc/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -83,11 +95,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 66610adf58884e068ac7eb8c886d7368
+      - 3723f4e6c2d84dbaa095e4ed6310824c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:38 GMT
+      - Mon, 18 May 2026 18:53:53 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -104,24 +116,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 66610adf58884e068ac7eb8c886d7368
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 3723f4e6c2d84dbaa095e4ed6310824c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-b213-77a5-a080-beec79693f2c/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-003c-7404-b425-5ac7eb5be8bc/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-b213-77a5-a080-beec79693f2c/","prn":"prn:core.task:019e0961-b213-77a5-a080-beec79693f2c","pulp_created":"2026-05-08T20:57:38.072908Z","pulp_last_updated":"2026-05-08T20:57:38.068491Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"66610adf58884e068ac7eb8c886d7368","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:38.080645Z","started_at":"2026-05-08T20:57:38.084470Z","finished_at":"2026-05-08T20:57:38.092543Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":false,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:38.088530Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-003c-7404-b425-5ac7eb5be8bc/","prn":"prn:core.task:019e3c70-003c-7404-b425-5ac7eb5be8bc","pulp_created":"2026-05-18T18:53:53.600080Z","pulp_last_updated":"2026-05-18T18:53:53.596676Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"3723f4e6c2d84dbaa095e4ed6310824c","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:53:53.609079Z","started_at":"2026-05-18T18:53:53.613295Z","finished_at":"2026-05-18T18:53:53.622178Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":false,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:53:53.617543Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -134,11 +152,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 66610adf58884e068ac7eb8c886d7368
+      - 3723f4e6c2d84dbaa095e4ed6310824c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:38 GMT
+      - Mon, 18 May 2026 18:53:53 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -155,24 +173,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 66610adf58884e068ac7eb8c886d7368
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 3723f4e6c2d84dbaa095e4ed6310824c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:38.088530Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:53.617543Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -185,11 +209,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 66610adf58884e068ac7eb8c886d7368
+      - 3723f4e6c2d84dbaa095e4ed6310824c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:38 GMT
+      - Mon, 18 May 2026 18:53:53 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-4.yml
+++ b/tests/fixtures/rpm_repository-4.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:38.088530Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:53.617543Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - b65adc17157c47e698788d7342acbf5f
+      - 8606eba782ea4cb1b62c7237a092992e
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:38 GMT
+      - Mon, 18 May 2026 18:53:54 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-5.yml
+++ b/tests/fixtures/rpm_repository-5.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:38.088530Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:53.617543Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":false,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 06bb4f21aa6940efa5de5f55640ed359
+      - 7c018bc16d274951bdd3cfa75f57dc63
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:39 GMT
+      - Mon, 18 May 2026 18:53:54 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"autopublish": true}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '21'
       Correlation-Id:
-      - 06bb4f21aa6940efa5de5f55640ed359
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 7c018bc16d274951bdd3cfa75f57dc63
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-b73f-7f07-aec0-11120045774e/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-0571-71cb-a859-9cabe6004ec2/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 06bb4f21aa6940efa5de5f55640ed359
+      - 7c018bc16d274951bdd3cfa75f57dc63
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:39 GMT
+      - Mon, 18 May 2026 18:53:54 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 06bb4f21aa6940efa5de5f55640ed359
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 7c018bc16d274951bdd3cfa75f57dc63
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-b73f-7f07-aec0-11120045774e/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-0571-71cb-a859-9cabe6004ec2/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-b73f-7f07-aec0-11120045774e/","prn":"prn:core.task:019e0961-b73f-7f07-aec0-11120045774e","pulp_created":"2026-05-08T20:57:39.393239Z","pulp_last_updated":"2026-05-08T20:57:39.391346Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"06bb4f21aa6940efa5de5f55640ed359","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:39.400904Z","started_at":"2026-05-08T20:57:39.404316Z","finished_at":"2026-05-08T20:57:39.412173Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:39.408006Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-0571-71cb-a859-9cabe6004ec2/","prn":"prn:core.task:019e3c70-0571-71cb-a859-9cabe6004ec2","pulp_created":"2026-05-18T18:53:54.933344Z","pulp_last_updated":"2026-05-18T18:53:54.930128Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"7c018bc16d274951bdd3cfa75f57dc63","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:53:54.940756Z","started_at":"2026-05-18T18:53:54.944108Z","finished_at":"2026-05-18T18:53:54.951990Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:53:54.947998Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 06bb4f21aa6940efa5de5f55640ed359
+      - 7c018bc16d274951bdd3cfa75f57dc63
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:39 GMT
+      - Mon, 18 May 2026 18:53:55 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - 06bb4f21aa6940efa5de5f55640ed359
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 7c018bc16d274951bdd3cfa75f57dc63
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:39.408006Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:54.947998Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - 06bb4f21aa6940efa5de5f55640ed359
+      - 7c018bc16d274951bdd3cfa75f57dc63
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:39 GMT
+      - Mon, 18 May 2026 18:53:55 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-6.yml
+++ b/tests/fixtures/rpm_repository-6.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:39.408006Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:54.947998Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - f62ec3d957834095b169acbaedb0d43d
+      - ce12c02f48d64a4fba5bc505054c092f
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:40 GMT
+      - Mon, 18 May 2026 18:53:55 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-7.yml
+++ b/tests/fixtures/rpm_repository-7.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:39.408006Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:54.947998Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d53c6ec1f93a41a1abca29a0c67080ee
+      - 46dee8f6251947c3aeed9961d3499269
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:40 GMT
+      - Mon, 18 May 2026 18:53:56 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"repo_config": {"gpgcheck": 1}}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '32'
       Correlation-Id:
-      - d53c6ec1f93a41a1abca29a0c67080ee
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 46dee8f6251947c3aeed9961d3499269
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-bc69-76b3-bb1f-a3b6b1e842aa/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-0aa3-75bd-ab05-65bc25cfdfee/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d53c6ec1f93a41a1abca29a0c67080ee
+      - 46dee8f6251947c3aeed9961d3499269
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:40 GMT
+      - Mon, 18 May 2026 18:53:56 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - d53c6ec1f93a41a1abca29a0c67080ee
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 46dee8f6251947c3aeed9961d3499269
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-bc69-76b3-bb1f-a3b6b1e842aa/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-0aa3-75bd-ab05-65bc25cfdfee/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-bc69-76b3-bb1f-a3b6b1e842aa/","prn":"prn:core.task:019e0961-bc69-76b3-bb1f-a3b6b1e842aa","pulp_created":"2026-05-08T20:57:40.716858Z","pulp_last_updated":"2026-05-08T20:57:40.713671Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"d53c6ec1f93a41a1abca29a0c67080ee","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:40.725553Z","started_at":"2026-05-08T20:57:40.728804Z","finished_at":"2026-05-08T20:57:40.736854Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:40.732838Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-0aa3-75bd-ab05-65bc25cfdfee/","prn":"prn:core.task:019e3c70-0aa3-75bd-ab05-65bc25cfdfee","pulp_created":"2026-05-18T18:53:56.261568Z","pulp_last_updated":"2026-05-18T18:53:56.260132Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"46dee8f6251947c3aeed9961d3499269","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:53:56.268100Z","started_at":"2026-05-18T18:53:56.271458Z","finished_at":"2026-05-18T18:53:56.279178Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:53:56.275205Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":0,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d53c6ec1f93a41a1abca29a0c67080ee
+      - 46dee8f6251947c3aeed9961d3499269
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:40 GMT
+      - Mon, 18 May 2026 18:53:56 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - d53c6ec1f93a41a1abca29a0c67080ee
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - 46dee8f6251947c3aeed9961d3499269
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:40.732838Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:56.275205Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d53c6ec1f93a41a1abca29a0c67080ee
+      - 46dee8f6251947c3aeed9961d3499269
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:41 GMT
+      - Mon, 18 May 2026 18:53:56 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-8.yml
+++ b/tests/fixtures/rpm_repository-8.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:40.732838Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:56.275205Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - d3dcf776e03a4aa7accc240abdc6b533
+      - c309ffaed72f45d3b4e9af38853fc5b7
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:41 GMT
+      - Mon, 18 May 2026 18:53:56 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/fixtures/rpm_repository-9.yml
+++ b/tests/fixtures/rpm_repository-9.yml
@@ -2,22 +2,28 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
     uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/?name=test_rpm_repository&offset=0&limit=1
   response:
     body:
-      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:40.732838Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:56.275205Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":0,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}]}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -30,11 +36,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:41 GMT
+      - Mon, 18 May 2026 18:53:57 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -51,27 +57,33 @@ interactions:
 - request:
     body: '{"retain_package_versions": 3}'
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
       - '30'
       Correlation-Id:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
       content-type:
       - application/json
     method: PATCH
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"task":"/pulp/api/v3/tasks/019e0961-c19c-70be-8524-2144d5b81d4e/"}'
+      string: '{"task":"/pulp/api/v3/tasks/019e3c70-0fce-70e5-ae52-20042c995318/"}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -84,11 +96,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:42 GMT
+      - Mon, 18 May 2026 18:53:57 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -105,24 +117,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/tasks/019e0961-c19c-70be-8524-2144d5b81d4e/
+    uri: http://pulp.example.org/pulp/api/v3/tasks/019e3c70-0fce-70e5-ae52-20042c995318/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/tasks/019e0961-c19c-70be-8524-2144d5b81d4e/","prn":"prn:core.task:019e0961-c19c-70be-8524-2144d5b81d4e","pulp_created":"2026-05-08T20:57:42.047536Z","pulp_last_updated":"2026-05-08T20:57:42.045420Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"e979f7a1ee5f4063a6e6f7d4757c85fd","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-08T20:57:42.057226Z","started_at":"2026-05-08T20:57:42.062737Z","finished_at":"2026-05-08T20:57:42.071315Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","shared:prn:core.domain:98d02688-8952-4c28-a37c-b8f1a8ffa1cd"],"result":{"prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","autopublish":true,"description":"repository
-        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-08T20:57:37.026223Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","compression_type":null,"pulp_last_updated":"2026-05-08T20:57:42.067388Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":3,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
+      string: '{"pulp_href":"/pulp/api/v3/tasks/019e3c70-0fce-70e5-ae52-20042c995318/","prn":"prn:core.task:019e3c70-0fce-70e5-ae52-20042c995318","pulp_created":"2026-05-18T18:53:57.585058Z","pulp_last_updated":"2026-05-18T18:53:57.583377Z","state":"completed","name":"pulpcore.app.tasks.base.ageneral_update","logging_cid":"dec52dd4fb8b429b87b3bfb3f8c3d54c","created_by":"/pulp/api/v3/users/1/","unblocked_at":"2026-05-18T18:53:57.592002Z","started_at":"2026-05-18T18:53:57.595223Z","finished_at":"2026-05-18T18:53:57.603973Z","error":null,"worker":null,"parent_task":null,"child_tasks":[],"task_group":null,"progress_reports":[],"created_resources":[],"created_resource_prns":[],"reserved_resources_record":["prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","shared:prn:core.domain:65e61fa4-37f6-4776-ac05-08e09a533a76"],"result":{"prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","name":"test_rpm_repository","layout":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","autopublish":true,"description":"repository
+        created via ansible","pulp_labels":{},"repo_config":{"gpgcheck":1},"pulp_created":"2026-05-18T18:53:52.390438Z","checksum_type":null,"versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","compression_type":null,"pulp_last_updated":"2026-05-18T18:53:57.599641Z","retain_checkpoints":null,"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","retain_repo_versions":null,"package_checksum_type":null,"metadata_checksum_type":null,"package_signing_service":null,"retain_package_versions":3,"metadata_signing_service":null,"package_signing_fingerprint":null}}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -135,11 +153,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:42 GMT
+      - Mon, 18 May 2026 18:53:57 GMT
       Referrer-Policy:
       - same-origin
       Server:
@@ -156,24 +174,30 @@ interactions:
 - request:
     body: null
     headers:
-      ? !!python/object/apply:multidict._multidict.istr
-      - Accept
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - Accept
+        state:
+          __istr_identity__: Accept
       : - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Correlation-Id:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
-      ? !!python/object/apply:multidict._multidict.istr
-      - User-Agent
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
+      ? !!python/object/new:multidict._multidict_py.istr
+        args:
+        - User-Agent
+        state:
+          __istr_identity__: User-Agent
       : - Squeezer/0.4.0-dev
     method: GET
-    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/
+    uri: http://pulp.example.org/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/
   response:
     body:
-      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/","prn":"prn:rpm.rpmrepository:019e0961-ae01-736a-947a-c953e56fc202","pulp_created":"2026-05-08T20:57:37.026223Z","pulp_last_updated":"2026-05-08T20:57:42.067388Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e0961-ae01-736a-947a-c953e56fc202/versions/0/","name":"test_rpm_repository","description":"repository
-        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e0961-a71e-77a3-a7f9-76461d5b1a16/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
+      string: '{"pulp_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/","prn":"prn:rpm.rpmrepository:019e3c6f-fb85-7d27-888e-ca1ca6e7ba38","pulp_created":"2026-05-18T18:53:52.390438Z","pulp_last_updated":"2026-05-18T18:53:57.599641Z","versions_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/","pulp_labels":{},"latest_version_href":"/pulp/api/v3/repositories/rpm/rpm/019e3c6f-fb85-7d27-888e-ca1ca6e7ba38/versions/0/","name":"test_rpm_repository","description":"repository
+        created via ansible","retain_repo_versions":null,"retain_checkpoints":null,"remote":"/pulp/api/v3/remotes/rpm/rpm/019e3c6f-f509-7ded-9cdf-7fccb2ab36f8/","autopublish":true,"metadata_signing_service":null,"package_signing_service":null,"package_signing_fingerprint":null,"retain_package_versions":3,"checksum_type":null,"metadata_checksum_type":null,"package_checksum_type":null,"sqlite_metadata":false,"repo_config":{"gpgcheck":1},"compression_type":null,"layout":null}'
     headers:
       Access-Control-Expose-Headers:
       - Correlation-ID
@@ -186,11 +210,11 @@ interactions:
       Content-Type:
       - application/json
       Correlation-ID:
-      - e979f7a1ee5f4063a6e6f7d4757c85fd
+      - dec52dd4fb8b429b87b3bfb3f8c3d54c
       Cross-Origin-Opener-Policy:
       - same-origin
       Date:
-      - Fri, 08 May 2026 20:57:42 GMT
+      - Mon, 18 May 2026 18:53:57 GMT
       Referrer-Policy:
       - same-origin
       Server:

--- a/tests/playbooks/file_repository.yaml
+++ b/tests/playbooks/file_repository.yaml
@@ -94,6 +94,30 @@
         that:
           - result.changed == false
 
+    - name: Add pulp_labels (dict) to repository
+      pulp.squeezer.file_repository:
+        name: test_file_repository
+        pulp_labels:
+          test_label: "1"
+        state: present
+      register: result
+    - name: Verify add pulp_labels (dict) to repository
+      assert:
+        that:
+          - 'result.changed == true'
+          - 'result.repository.pulp_labels == {"test_label": "1"}'
+
+    - name: Add pulp_labels (string) to repository (Validate no change)
+      pulp.squeezer.file_repository:
+        name: test_file_repository
+        pulp_labels: '{"test_label": "1"}'
+        state: present
+      register: result
+    - name: Verify add pulp_labels (string) to repository (Validate no change)
+      assert:
+        that:
+          - 'result.changed == false'
+
     - name: Fake modify repository
       pulp.squeezer.file_repository:
         name: test_file_repository


### PR DESCRIPTION
Resolves https://github.com/pulp/squeezer/issues/243

Adds the pulp_labels parameter to the file_repository module and extends the tests based on the ones from rpm_repository.