### PR TITLE
Add tests for Ansible 2.21 and allow installation up to 2.25 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
             ansible: "stable-2.20"
             image_tag: "nightly"
             lower_bounds: true
+          - python: "3.14"
+            ansible: "stable-2.21"
+            image_tag: "nightly"
+            lower_bounds: true
     steps:
       - uses: "actions/checkout@v6"
       - uses: "actions/cache@v5"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -43,5 +43,5 @@ action_groups:
   - task
   - user
   - x509_cert_guard
-requires_ansible: '>=2.16.0,<2.21'
+requires_ansible: '>=2.16.0,<2.25'
 ...


### PR DESCRIPTION
Resolves #245 squeezer will keep breaking if we tightly constrain the newest ansible it supports